### PR TITLE
Allowing the generation of a single instruction

### DIFF
--- a/libjas/codegen.c
+++ b/libjas/codegen.c
@@ -208,6 +208,6 @@ static buffer_t assemble(enum modes mode, instruction_t *instr_arr, size_t arr_s
   return buf;
 }
 
-inline buffer_t assemble_instr(enum modes mode, instruction_t instr, enum codegen_modes modes) {
-  return codegen(mode, &instr, sizeof(instruction_t), modes);
+inline buffer_t assemble_instr(enum modes mode, instruction_t instr) {
+  return codegen(mode, &instr, sizeof(instruction_t), CODEGEN_RAW);
 }

--- a/libjas/codegen.c
+++ b/libjas/codegen.c
@@ -207,3 +207,7 @@ static buffer_t assemble(enum modes mode, instruction_t *instr_arr, size_t arr_s
 
   return buf;
 }
+
+inline buffer_t assemble_instr(enum modes mode, instruction_t instr, enum codegen_modes modes) {
+  return codegen(mode, &instr, sizeof(instruction_t), modes);
+}

--- a/libjas/include/codegen.h
+++ b/libjas/include/codegen.h
@@ -63,11 +63,11 @@ buffer_t codegen(enum modes mode, instruction_t *instr_arr, size_t arr_size, enu
  *
  * @param mode The mode to generate the machine code in
  * @param instr The instruction to generate the code from
- * @param modes The output mode of the codegen function
  *
  * @return The buffer struct containing the machine code
  *
  * @see `codegen`
  */
-inline buffer_t assemble_instr(enum modes mode, instruction_t instr, enum codegen_modes modes) {
+inline buffer_t assemble_instr(enum modes mode, instruction_t instr);
+
 #endif

--- a/libjas/include/codegen.h
+++ b/libjas/include/codegen.h
@@ -55,4 +55,19 @@ enum codegen_modes {
  */
 buffer_t codegen(enum modes mode, instruction_t *instr_arr, size_t arr_size, enum codegen_modes exec_mode);
 
+/**
+ * Wrapper function for the `codegen` function that gives boiler-
+ * plate code to generate the binary of a single instruction given
+ * in the instruction struct form, but not an array as seen in the
+ * `codegen` function.
+ *
+ * @param mode The mode to generate the machine code in
+ * @param instr The instruction to generate the code from
+ * @param modes The output mode of the codegen function
+ *
+ * @return The buffer struct containing the machine code
+ *
+ * @see `codegen`
+ */
+inline buffer_t assemble_instr(enum modes mode, instruction_t instr, enum codegen_modes modes) {
 #endif


### PR DESCRIPTION
This pull request implements a wrapper function that allows the users to generate the raw assembly code without the hassle of setting up an array of instructions. This is more convent for apps like JIT compilers and compilers that can give enhanced error messages as well (ig)