### PR TITLE
Added support for varying displacement sizes 

### DIFF
--- a/libjas/include/operand.h
+++ b/libjas/include/operand.h
@@ -154,6 +154,10 @@ enum enc_ident op_ident_identify(enum operands *input);
  * @note Function also performs checks for RIP, ESP, IP instr-
  * uction pointers for offset and ModR/M bytes and modes.
  *
+ * @note The function requires the offset value to be typed as
+ * signed types to prevent confusion and to match with the Intel
+ * -required specifications as outlined.
+ *
  * @see `operand_t`
  */
 uint8_t op_modrm_mode(operand_t input);

--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -44,8 +44,13 @@ uint8_t op_modrm_mode(operand_t input) {
   if (op_m(input.type) && input.offset == 0)
     return OP_MODRM_INDIRECT;
 
-  else if (input.offset != 0)
-    return OP_MODRM_DISP32;
+  if (input.offset != 0) {
+    if (input.offset > (uintmax_t)UINT32_MAX) err("Displacement value is too large.");
+    if (input.offset > (uintmax_t)UINT8_MAX) // Size of a `uint8_t`
+      return OP_MODRM_DISP32;
+
+    return OP_MODRM_DISP8; // Revert to 8-bit displacement when extra space is not needed
+  }
 
   return OP_MODRM_REG;
 }

--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -45,8 +45,8 @@ uint8_t op_modrm_mode(operand_t input) {
     return OP_MODRM_INDIRECT;
 
   if (input.offset != 0) {
-    if ((uintmax_t)input.offset > UINT32_MAX) err("Displacement value is too large.");
-    if ((uintmax_t)input.offset > UINT8_MAX) // Size of a `uint8_t`
+    if ((intmax_t)input.offset > INT32_MAX) err("Displacement value is too large.");
+    if ((intmax_t)input.offset > INT8_MAX) // Size of a `uint8_t`
       return OP_MODRM_DISP32;
 
     return OP_MODRM_DISP8; // Revert to 8-bit displacement when extra space is not needed

--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -45,8 +45,8 @@ uint8_t op_modrm_mode(operand_t input) {
     return OP_MODRM_INDIRECT;
 
   if (input.offset != 0) {
-    if (input.offset > (uintmax_t)UINT32_MAX) err("Displacement value is too large.");
-    if (input.offset > (uintmax_t)UINT8_MAX) // Size of a `uint8_t`
+    if ((uintmax_t)input.offset > UINT32_MAX) err("Displacement value is too large.");
+    if ((uintmax_t)input.offset > UINT8_MAX) // Size of a `uint8_t`
       return OP_MODRM_DISP32;
 
     return OP_MODRM_DISP8; // Revert to 8-bit displacement when extra space is not needed

--- a/tests/operand.c
+++ b/tests/operand.c
@@ -60,7 +60,7 @@ Test(operand, modrm_mode) {
       {op_construct_operand(OP_M64, 0, &(enum registers){REG_RAX}), OP_MODRM_INDIRECT},
       {op_construct_operand(OP_M64, 8, &(enum registers){REG_RAX}), OP_MODRM_DISP8},
       {op_construct_operand(OP_M64, 0, &(enum registers){REG_RBP}), OP_MODRM_DISP8},
-      {op_construct_operand(OP_M64, 0xFFFF, &(enum registers){REG_RAX}), OP_MODRM_DISP8},
+      {op_construct_operand(OP_M64, 0xFFFF, &(enum registers){REG_RAX}), OP_MODRM_DISP32},
   };
 
   for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {

--- a/tests/operand.c
+++ b/tests/operand.c
@@ -57,11 +57,10 @@ Test(operand, modrm_mode) {
     int expected_mode;
   } test_cases[] = {
       {op_construct_operand(OP_M64, 0, &(enum registers){REG_RIP}), OP_MODRM_INDIRECT},
-      {op_construct_operand(OP_M64, 0, &(enum registers){REG_EIP}), OP_MODRM_INDIRECT},
-      {op_construct_operand(OP_M64, 0, &(enum registers){REG_IP}), OP_MODRM_INDIRECT},
       {op_construct_operand(OP_M64, 0, &(enum registers){REG_RAX}), OP_MODRM_INDIRECT},
-      {op_construct_operand(OP_M64, 8, &(enum registers){REG_RAX}), OP_MODRM_DISP32},
+      {op_construct_operand(OP_M64, 8, &(enum registers){REG_RAX}), OP_MODRM_DISP8},
       {op_construct_operand(OP_M64, 0, &(enum registers){REG_RBP}), OP_MODRM_DISP8},
+      {op_construct_operand(OP_M64, 0xFFFF, &(enum registers){REG_RAX}), OP_MODRM_DISP8},
   };
 
   for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {


### PR DESCRIPTION
This pull request added the functionality to allow the size of the offset to be *variable* and not defaulted to `OP_MODRM_DISP32`. With this change, all displacement sizes are originally set to a single byte wide (`OP_MODRM_DISP8`) and expands up to a 4 bytes-wide displacement. Having the option to expand up to 4 bytes gives the flexibility and allows the assembler to omit any extra 0s appended to the end.