### PR TITLE
Changed type

### DIFF
--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -71,7 +71,7 @@ static void write_offset(uint8_t mode, buffer_t *buf, operand_t *op_arr, uint8_t
     break;
 
   case OP_MODRM_DISP32:
-    buf_write(buf, (int8_t *)&op_arr[index].offset, 4);
+    buf_write(buf, (uint8_t *)&(int32_t){op_arr[index].offset}, 4);
     break;
   }
 }

--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -67,11 +67,11 @@ static void ref_label(operand_t *op_arr, buffer_t *buf, uint8_t index) {
 static void write_offset(uint8_t mode, buffer_t *buf, operand_t *op_arr, uint8_t index) {
   switch (mode) {
   case OP_MODRM_DISP8:
-    buf_write_byte(buf, (uint8_t)op_arr[index].offset);
+    buf_write_byte(buf, (int8_t)op_arr[index].offset);
     break;
 
   case OP_MODRM_DISP32:
-    buf_write(buf, (uint8_t *)&op_arr[index].offset, 4);
+    buf_write(buf, (int8_t *)&op_arr[index].offset, 4);
     break;
   }
 }


### PR DESCRIPTION
Commit details:
> Changed typcast for offsets from `uint8_t`s to a signed `int8_t` as well as the signed double-worded counterpats, as specified in commit c78baced5e91160be835d4c90204c5eb10fb0ab0 where the offset type was changed to a signed value. (Specified in the Intel man- ual as well!)
>
>
> Note - The 4 byte displacement offset is NOT typed as `uint32_t` or any 4 byte-sized data type due to the `buf_write` function requiring an array of `uint8_t`s. However, they have been bunched together in a int32_t value with is abstracted as an unsigned char array?!?!?