### PR TITLE
Encoder macro changes/refactor

### DIFF
--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -25,7 +25,6 @@
 
 #include "encoder.h"
 #include "buffer.h"
-#include "endian.h"
 #include "error.h"
 #include "instruction.h"
 #include "label.h"

--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -36,9 +36,6 @@
 #define OP_OPCODE_HELPER (op_sizeof(op_arr[0].type) == 8 ? instr_ref->byte_instr_opcode : instr_ref->opcode)
 #define EMPTY_SIB 0x24
 
-#define DEFINE_ENCODER(ident) \
-  void ident(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode)
-
 /**
  * @brief
  * - A label is a memory address NOT a value!

--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -29,6 +29,9 @@
 #include "buffer.h"
 #include "mode.h"
 
+#define DEFINE_ENCODER(ident) \
+  void ident(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode)
+
 // Forward declarations -  See `instruction.h` and `operand.h` respectively
 typedef struct instr_encode_table instr_encode_table_t;
 typedef struct operand operand_t;

--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -64,18 +64,17 @@ enum enc_ident {
  * from `instruction.h` and the corresponding `instruction.c`.
  */
 
-void d(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode);
-void i(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode);
+DEFINE_ENCODER(d);
+DEFINE_ENCODER(i);
 
-void m(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode);
-void mi(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode);
-void mr(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode);
+DEFINE_ENCODER(m);
+DEFINE_ENCODER(mi);
+DEFINE_ENCODER(mr);
 
-void o(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode);
-void oi(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode);
+DEFINE_ENCODER(o);
+DEFINE_ENCODER(oi);
 
-void rm(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode);
-
-void zo(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode);
+DEFINE_ENCODER(rm);
+DEFINE_ENCODER(zo);
 
 #endif

--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -29,9 +29,6 @@
 #include "buffer.h"
 #include "mode.h"
 
-#define DEFINE_ENCODER(ident) \
-  void ident(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode)
-
 // Forward declarations -  See `instruction.h` and `operand.h` respectively
 typedef struct instr_encode_table instr_encode_table_t;
 typedef struct operand operand_t;
@@ -54,6 +51,17 @@ enum enc_ident {
   OP_D,
   OP_O,
 };
+
+/**
+ * Macro definition for the encoder function signature,
+ * this function signature and it's parameters are all
+ * documented in `instruction.h` with the `instr_encoder_t`
+ * typedef.
+ *
+ * @see `instr_encoder_t`
+ */
+#define DEFINE_ENCODER(ident) \
+  void ident(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode)
 
 /**
  * @brief


### PR DESCRIPTION
This Pull request describes the changes of the encoder function signature macro `DEFINE_ENCODER`'s move to the `encoder.h` header file as well as added documentation