### PR TITLE
Removed `inline` attribute to the function signature

### DIFF
--- a/libjas/codegen.c
+++ b/libjas/codegen.c
@@ -208,6 +208,6 @@ static buffer_t assemble(enum modes mode, instruction_t *instr_arr, size_t arr_s
   return buf;
 }
 
-inline buffer_t assemble_instr(enum modes mode, instruction_t instr) {
+buffer_t assemble_instr(enum modes mode, instruction_t instr) {
   return codegen(mode, &instr, sizeof(instruction_t), CODEGEN_RAW);
 }

--- a/libjas/include/codegen.h
+++ b/libjas/include/codegen.h
@@ -68,6 +68,6 @@ buffer_t codegen(enum modes mode, instruction_t *instr_arr, size_t arr_size, enu
  *
  * @see `codegen`
  */
-inline buffer_t assemble_instr(enum modes mode, instruction_t instr);
+buffer_t assemble_instr(enum modes mode, instruction_t instr);
 
 #endif


### PR DESCRIPTION
For some reason the `assemble_instr` funcitonc cannot be called using the `inline` keyword aimed at reducing production code size, and produces a linker error during link-time.