### PR TITLE
Added `instr_get_tab()`

### DIFF
--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -155,7 +155,17 @@ instr_encoder_t instr_encode_func(enum enc_ident input);
   (uint8_t) x.instr >= (uint8_t)INSTR_DIR_LOCAL_LABEL && \
       (uint8_t)x.instr <= (uint8_t)INSTR_DIR_EXTERN_LABEL
 
-// TODO - Document
+/**
+ * Function for getting the instruction table based on the instruction
+ * struct provided. The function will return a instruction table struct
+ * as described above in this header file.
+ *
+ * @param instr The instruction struct to get the identifier from
+ * @return The instruction table struct
+ *
+ * @see `instr_encode_table_t`
+ * @see `instruction_t`
+ */
 instr_encode_table_t instr_get_tab(instruction_t instr);
 
 #endif

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -150,4 +150,12 @@ instr_encoder_t instr_encode_func(enum enc_ident input);
 #define INSTR_NULL \
   (instruction_t) { .instr = NULL, .operands = NULL }
 
+// Macro for checking if the instruction is a label and shall be handled
+#define IS_LABEL(x)                                      \
+  (uint8_t) x.instr >= (uint8_t)INSTR_DIR_LOCAL_LABEL && \
+      (uint8_t)x.instr <= (uint8_t)INSTR_DIR_EXTERN_LABEL
+
+// TODO - Document
+instr_encode_table_t instr_get_tab(instruction_t instr);
+
 #endif

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -174,6 +174,37 @@ instr_encode_table_t *instr_table[] =
 
 // clang-format on
 
+#define CURR_TABLE instr_table[instr.instr][j]
+
+instr_encode_table_t instr_get_tab(instruction_t instr) {
+  if (IS_LABEL(instr)) return INSTR_TERMINATOR; // aka empty
+  const enum operands operand_list[4] = {
+      instr.operands[0].type,
+      instr.operands[1].type,
+      instr.operands[2].type,
+      instr.operands[3].type,
+  };
+
+  enum enc_ident ident = op_ident_identify(operand_list);
+  if (instr.instr == INSTR_MOV) {
+    if (ident == OP_MI) ident = OP_OI;
+    if (ident == OP_I) ident = OP_O;
+  }
+
+  unsigned int j = 0;
+  while (CURR_TABLE.opcode_size != 0) {
+    if (CURR_TABLE.ident == ident) {
+      return CURR_TABLE;
+      break;
+    }
+    j++;
+  }
+
+  // fall-through; no corresponding instruction opcode found
+  err("No corrsponding instruction opcode found.");
+  return INSTR_TERMINATOR; // aka empty
+}
+
 instr_encoder_t instr_encode_func(enum enc_ident input) {
   instr_encoder_t lookup[] = {&mr, &rm, &oi, &mi, &i, &m, &zo, &d, &o};
   return lookup[(size_t)input];


### PR DESCRIPTION
This branch describes the introduction and implementation of the `insert_get_tab()`. As outlined in the commit messages, this function will take in a instruction structure and fetch the corresponding instruction encoder table by looking up a specific table and sorting through a list of identities, similar to quadratics if you recall from school ;).