### PR TITLE
Use the `INSTR_DIRECTIVE` macro

### DIFF
--- a/libjas/codegen.c
+++ b/libjas/codegen.c
@@ -153,7 +153,7 @@ static buffer_t assemble(enum modes mode, instruction_t *instr_arr, size_t arr_s
 
     /* -- Handle assembler directives -- */
 
-    if (instr_arr[i].instr > INSTR_SYSCALL) {
+    if (INSTR_DIRECTIVE(instr_arr[i].instr)) {
       if (instr_arr[i].instr == INSTR_DIR_WRT_BUF) {
         const buffer_t *data = (buffer_t *)instr_arr[i].operands[0].data;
         buf_write(&buf, data->data, data->len);


### PR DESCRIPTION
This pull just simply refactored a if statement with the `INSTR_DIRECTIVE` macro as described in the commit message:

> Since the introduction of the `INSTR_DIRECTIVE` which does a check for if a enumeration is a directive instruction or not by casting it into a integer and comparing the values against the last instr- uction; somehow, this if statement was lost during the migration process (somewhere)