### PR TITLE
Encoder identity refactoring changes

### DIFF
--- a/libjas/codegen.c
+++ b/libjas/codegen.c
@@ -24,6 +24,7 @@
  */
 
 #include "codegen.h"
+#include "encoder.h"
 #include "error.h"
 #include "exe.h"
 #include "label.h"
@@ -185,7 +186,7 @@ static buffer_t assemble(enum modes mode, instruction_t *instr_arr, size_t arr_s
     const instr_encode_table_t ref = tabs[i];
     instruction_t current = instr_arr[i];
     if (ref.pre != NULL) ref.pre(current.operands, &buf, &ref, (enum modes)mode);
-    instr_encode_func(ref.ident)(current.operands, &buf, &ref, (enum modes)mode);
+    enc_lookup(ref.ident)(current.operands, &buf, &ref, (enum modes)mode);
   }
 
   return buf;

--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -153,7 +153,7 @@ DEFINE_ENCODER(mi) {
   }
 }
 
-static void mr_rm_ref(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode, bool is_rm) {
+static void rm_mr_common(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode, enum enc_ident ident) {
   /**
    * @brief This opcode identity is a "Common ground for MR and RM"
    * Since rm and mr just has to be flipped, we can just use a boolean
@@ -162,6 +162,8 @@ static void mr_rm_ref(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *in
    * @note An empty SIB byte will be written if the register is 4
    * (A rsp, sp or esp) register that activates the SIB byte.
    */
+
+  const bool is_rm = ident == ENC_RM;
 
   // Register - Since this is accessed quite often
   register const uint8_t reg_idx = is_rm ? 0 : 1;
@@ -215,8 +217,8 @@ static void mr_rm_ref(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *in
   write_offset(mod, buf, op_arr, rm_idx);
 }
 
-DEFINE_ENCODER(mr) { mr_rm_ref(op_arr, buf, instr_ref, mode, false); }
-DEFINE_ENCODER(rm) { mr_rm_ref(op_arr, buf, instr_ref, mode, true); }
+DEFINE_ENCODER(mr) { rm_mr_common(op_arr, buf, instr_ref, mode, ENC_MR); }
+DEFINE_ENCODER(rm) { rm_mr_common(op_arr, buf, instr_ref, mode, ENC_RM); }
 
 DEFINE_ENCODER(o) {
   const uint8_t reg = reg_lookup_val(op_arr[0].data);

--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -239,3 +239,8 @@ DEFINE_ENCODER(zo) {
   check_mode(mode, instr_ref->support);
   buf_write(buf, instr_ref->opcode, instr_ref->opcode_size);
 }
+
+encoder_t enc_lookup(enum enc_ident input) {
+  encoder_t lookup[] = {&mr, &rm, &oi, &mi, &i, &m, &zo, &d, &o};
+  return lookup[(size_t)input];
+}

--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -60,29 +60,16 @@ enum enc_ident {
  *
  * @see `instr_encoder_t`
  */
-#define DEFINE_ENCODER(ident) \
+#define DEFINE_ENCODER(ident, ...) \
   void ident(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode)
 
-/**
- * @brief
- * The encoder function signature for the different operand
- * identifiers. The encoder functions are used to encode the
- * operands into machine code while incorporating the opcodes
- * and all other necessary information based off lookup tables
- * from `instruction.h` and the corresponding `instruction.c`.
- */
+/* --- Register encoder function declarations here: --- */
+#define DECLARE_ENCODER_LIST(func_name, ...) \
+  DEFINE_ENCODER(func_name, __VA_ARGS__);    \
+  DECLARE_ENCODER_LIST(__VA_ARGS__)
 
-DEFINE_ENCODER(d);
-DEFINE_ENCODER(i);
+DECLARE_ENCODER_LIST(mr, rm, oi, mi, i, m, zo, d, o);
 
-DEFINE_ENCODER(m);
-DEFINE_ENCODER(mi);
-DEFINE_ENCODER(mr);
-
-DEFINE_ENCODER(o);
-DEFINE_ENCODER(oi);
-
-DEFINE_ENCODER(rm);
-DEFINE_ENCODER(zo);
+#undef DECLARE_ENCODER_LIST
 
 #endif

--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -55,21 +55,44 @@ enum enc_ident {
 /**
  * Macro definition for the encoder function signature,
  * this function signature and it's parameters are all
- * documented in `instruction.h` with the `instr_encoder_t`
- * typedef.
+ * documented below.
  *
- * @see `instr_encoder_t`
+ * For very very special cases where you need to define
+ * a custom encoder function, or if you need to reference
+ * it in a different file, you can use this macro, instead
+ * of using the `enc_lookup()` function.
+ *
+ * @see `encoder_t`
  */
 #define DEFINE_ENCODER(ident, ...) \
   void ident(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode)
 
-/* --- Register encoder function declarations here: --- */
-#define DECLARE_ENCODER_LIST(func_name, ...) \
-  DEFINE_ENCODER(func_name, __VA_ARGS__);    \
-  DECLARE_ENCODER_LIST(__VA_ARGS__)
+/**
+ * Type wrapper for the instruction encoder function pointer. Where
+ * each operand encoder function takes an array of operands and
+ * a buffer to write the encoded instruction to.
+ *
+ * (Based on the operand identities like MR, RM, etc.)
+ *
+ * @param op_arr The array of operands to encode
+ * @param buf The buffer to write the encoded instruction to
+ * @param instr_ref The instruction reference table
+ * @param mode The operating mode of the instruction
+ *
+ * @note All encoder functions will conform to this signature.
+ */
+typedef void (*encoder_t)(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode);
 
-DECLARE_ENCODER_LIST(mr, rm, oi, mi, i, m, zo, d, o);
-
-#undef DECLARE_ENCODER_LIST
+/**
+ * Lookup table for the different instruction encoder functions.
+ * The lookup table is indexed by the operand encoding identity
+ * and the corresponding encoder function is returned.
+ *
+ * @see `encoder.c`
+ *
+ * @param input The instruction encoding identity
+ * @return The instruction encoder function pointer
+ */
+encoder_t instr_encode_func(enum enc_ident input);
 
 #endif

--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -41,15 +41,15 @@ typedef struct operand operand_t;
  * methods in the main source file - `encoder.c`.
  */
 enum enc_ident {
-  OP_MR,
-  OP_RM,
-  OP_OI,
-  OP_MI,
-  OP_I,
-  OP_M,
-  OP_ZO,
-  OP_D,
-  OP_O,
+  ENC_MR,
+  ENC_RM,
+  ENC_OI,
+  ENC_MI,
+  ENC_I,
+  ENC_M,
+  ENC_ZO,
+  ENC_D,
+  ENC_O,
 };
 
 /**

--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -93,6 +93,6 @@ typedef void (*encoder_t)(operand_t *op_arr, buffer_t *buf, instr_encode_table_t
  * @param input The instruction encoding identity
  * @return The instruction encoder function pointer
  */
-encoder_t instr_encode_func(enum enc_ident input);
+encoder_t enc_lookup(enum enc_ident input);
 
 #endif

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -91,6 +91,9 @@ enum instructions {
   INSTR_DIR_EXTERN_LABEL,
 };
 
+// Alias type for the encoder `encoder_t` function pointer. - See `encoder.h`
+typedef encoder_t pre_encoder_t;
+
 struct instr_encode_table {
   enum enc_ident ident;         /* Operand encoding identity */
   uint8_t opcode_ext;           /* Opcode extension */
@@ -98,7 +101,7 @@ struct instr_encode_table {
   mode_support_t support;       /* Support status of the instruction (Optional, Would be set to "all" if not used) */
   uint8_t byte_instr_opcode[3]; /* 8 bit opcode fallback of the instruction */
   uint8_t opcode_size;          /* Size of the opcode (max. 3 bytes)*/
-  encoder_t pre;                /* Pre-encoder processor function (Optional, null if not applicable) */
+  pre_encoder_t pre;            /* Pre-encoder processor function (Optional, null if not applicable) */
 };
 
 /**

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -91,22 +91,6 @@ enum instructions {
   INSTR_DIR_EXTERN_LABEL,
 };
 
-/**
- * Type wrapper for the instruction encoder function pointer. Where
- * each operand encoder function takes an array of operands and
- * a buffer to write the encoded instruction to.
- *
- * (Based on the operand identities like MR, RM, etc.)
- *
- * @param op_arr The array of operands to encode
- * @param buf The buffer to write the encoded instruction to
- * @param instr_ref The instruction reference table
- * @param mode The operating mode of the instruction
- *
- * @note All encoder functions will conform to this signature.
- */
-typedef void (*instr_encoder_t)(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode);
-
 struct instr_encode_table {
   enum enc_ident ident;         /* Operand encoding identity */
   uint8_t opcode_ext;           /* Opcode extension */
@@ -114,7 +98,7 @@ struct instr_encode_table {
   mode_support_t support;       /* Support status of the instruction (Optional, Would be set to "all" if not used) */
   uint8_t byte_instr_opcode[3]; /* 8 bit opcode fallback of the instruction */
   uint8_t opcode_size;          /* Size of the opcode (max. 3 bytes)*/
-  instr_encoder_t pre;          /* Pre-encoder processor function (Optional, null if not applicable) */
+  encoder_t pre;                /* Pre-encoder processor function (Optional, null if not applicable) */
 };
 
 /**
@@ -127,14 +111,6 @@ typedef struct {
   enum instructions instr; /* Type of instruction */
   operand_t *operands;     /* Operands of the instruction */
 } instruction_t;
-
-/**
- * Lookup table for the different instruction class encoders.
- *
- * @param input The instruction encoding identity
- * @return The instruction encoder function pointer
- */
-instr_encoder_t instr_encode_func(enum enc_ident input);
 
 #define INSTR_TERMINATOR         \
   (instr_encode_table_t) {       \

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -48,10 +48,10 @@ static void pre_imm(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *inst
 }
 
 static instr_encode_table_t mov[] = {
-    {OP_MR, NULL, {0x89}, MODE_SUPPORT_ALL, {0x88}, 1, &same_operand_sizes},
-    {OP_RM, NULL, {0x8B}, MODE_SUPPORT_ALL, {0x8A}, 1, &same_operand_sizes},
-    {OP_OI, NULL, {0xB8}, MODE_SUPPORT_ALL, {0xB0}, 1, &same_operand_sizes},
-    {OP_MI, 0b10000000, {0xC7}, MODE_SUPPORT_ALL, {0xC6}, 1, &pre_imm},
+    {ENC_MR, NULL, {0x89}, MODE_SUPPORT_ALL, {0x88}, 1, &same_operand_sizes},
+    {ENC_RM, NULL, {0x8B}, MODE_SUPPORT_ALL, {0x8A}, 1, &same_operand_sizes},
+    {ENC_OI, NULL, {0xB8}, MODE_SUPPORT_ALL, {0xB0}, 1, &same_operand_sizes},
+    {ENC_MI, 0b10000000, {0xC7}, MODE_SUPPORT_ALL, {0xC6}, 1, &pre_imm},
 
     INSTR_TERMINATOR,
 };
@@ -67,20 +67,20 @@ static void pre_lea(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *inst
 // clang-format off
 
 #define INSTR_GENERAL(rm, rm_byte, mr, mr_byte,i, i_byte, mi_ext, mi, mi_byte)  \
-      {OP_MR, NULL, {mr}, MODE_SUPPORT_ALL, {mr_byte}, 1, &same_operand_sizes},        \
-      {OP_RM, NULL, {rm}, MODE_SUPPORT_ALL, {rm_byte}, 1, &same_operand_sizes},        \
-      {OP_MI, mi_ext, {mi}, MODE_SUPPORT_ALL, {mi_byte}, 1, &pre_imm},          \
-      {OP_I, NULL, {i}, MODE_SUPPORT_ALL, {i_byte}, 1, &pre_imm},               \
+      {ENC_MR, NULL, {mr}, MODE_SUPPORT_ALL, {mr_byte}, 1, &same_operand_sizes},        \
+      {ENC_RM, NULL, {rm}, MODE_SUPPORT_ALL, {rm_byte}, 1, &same_operand_sizes},        \
+      {ENC_MI, mi_ext, {mi}, MODE_SUPPORT_ALL, {mi_byte}, 1, &pre_imm},          \
+      {ENC_I, NULL, {i}, MODE_SUPPORT_ALL, {i_byte}, 1, &pre_imm},               \
       INSTR_TERMINATOR,
 
 // clang-format on
 
-static instr_encode_table_t lea[] = {{OP_RM, NULL, {0x8D}, MODE_SUPPORT_ALL, {0x8D}, 1, &pre_lea}, INSTR_TERMINATOR};
+static instr_encode_table_t lea[] = {{ENC_RM, NULL, {0x8D}, MODE_SUPPORT_ALL, {0x8D}, 1, &pre_lea}, INSTR_TERMINATOR};
 
 static instr_encode_table_t add[] = {INSTR_GENERAL(0x03, 0x02, 0x01, 0x00, 0x03, 0x02, 0b10000000, 0x81, 0x80)};
 static instr_encode_table_t sub[] = {INSTR_GENERAL(0x2B, 0x2A, 0x28, 0x29, 0x2C, 0x2D, 5, 0x81, 0x80)};
-static instr_encode_table_t mul[] = {{OP_M, 4, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
-static instr_encode_table_t div[] = {{OP_M, 6, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
+static instr_encode_table_t mul[] = {{ENC_M, 4, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
+static instr_encode_table_t div[] = {{ENC_M, 6, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
 
 // Note all or, and and xor instructions have a imm8 which is not supported
 
@@ -90,10 +90,10 @@ static instr_encode_table_t xor [] = {INSTR_GENERAL(0x33, 0x32, 0x31, 0x30, 0x35
 
 // ---
 
-static instr_encode_table_t _not[] = {{OP_M, 2, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
+static instr_encode_table_t _not[] = {{ENC_M, 2, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
 
-static instr_encode_table_t inc[] = {{OP_M, 0, {0xFF}, MODE_SUPPORT_ALL, {0xFE}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
-static instr_encode_table_t dec[] = {{OP_M, 1, {0xFF}, MODE_SUPPORT_ALL, {0xFE}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
+static instr_encode_table_t inc[] = {{ENC_M, 0, {0xFF}, MODE_SUPPORT_ALL, {0xFE}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
+static instr_encode_table_t dec[] = {{ENC_M, 1, {0xFF}, MODE_SUPPORT_ALL, {0xFE}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
 
 static void pre_jcc_no_byte(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
   if (op_sizeof(op_arr[0].type) == 8)
@@ -101,19 +101,19 @@ static void pre_jcc_no_byte(operand_t *op_arr, buffer_t *buf, instr_encode_table
 }
 
 static instr_encode_table_t jmp[] = {
-    {OP_D, NULL, {0xE9}, MODE_SUPPORT_ALL, {0xEB}, 1, NULL},
-    {OP_M, 4, {0xFF}, MODE_SUPPORT_ALL, {0x90}, 1, &pre_imm},
+    {ENC_D, NULL, {0xE9}, MODE_SUPPORT_ALL, {0xEB}, 1, NULL},
+    {ENC_M, 4, {0xFF}, MODE_SUPPORT_ALL, {0x90}, 1, &pre_imm},
     INSTR_TERMINATOR,
 };
 
-static instr_encode_table_t je[] = {{OP_D, NULL, {0x0f, 0x84}, MODE_SUPPORT_ALL, {0x090, 0x74}, 2, NULL}, INSTR_TERMINATOR};
-static instr_encode_table_t jne[] = {{OP_D, NULL, {0x0f, 0x85}, MODE_SUPPORT_ALL, {0x00, 0x00}, 2, &pre_jcc_no_byte}, INSTR_TERMINATOR};
-static instr_encode_table_t jz[] = {{OP_D, NULL, {0x0f, 0x84}, MODE_SUPPORT_ALL, {0x00, 0x00}, 2, &pre_jcc_no_byte}, INSTR_TERMINATOR};
-static instr_encode_table_t jnz[] = {{OP_D, NULL, {0x0f, 0x85}, MODE_SUPPORT_ALL, {0x90, 0x75}, 2, NULL}, INSTR_TERMINATOR};
+static instr_encode_table_t je[] = {{ENC_D, NULL, {0x0f, 0x84}, MODE_SUPPORT_ALL, {0x090, 0x74}, 2, NULL}, INSTR_TERMINATOR};
+static instr_encode_table_t jne[] = {{ENC_D, NULL, {0x0f, 0x85}, MODE_SUPPORT_ALL, {0x00, 0x00}, 2, &pre_jcc_no_byte}, INSTR_TERMINATOR};
+static instr_encode_table_t jz[] = {{ENC_D, NULL, {0x0f, 0x84}, MODE_SUPPORT_ALL, {0x00, 0x00}, 2, &pre_jcc_no_byte}, INSTR_TERMINATOR};
+static instr_encode_table_t jnz[] = {{ENC_D, NULL, {0x0f, 0x85}, MODE_SUPPORT_ALL, {0x90, 0x75}, 2, NULL}, INSTR_TERMINATOR};
 
 static instr_encode_table_t call[] = {
-    {OP_D, NULL, {0xE8}, MODE_SUPPORT_ALL, {0xEB}, 1, NULL},
-    {OP_M, 2, {0xFF}, MODE_SUPPORT_ALL, {0x90}, 1, &pre_imm},
+    {ENC_D, NULL, {0xE8}, MODE_SUPPORT_ALL, {0xEB}, 1, NULL},
+    {ENC_M, 2, {0xFF}, MODE_SUPPORT_ALL, {0x90}, 1, &pre_imm},
     INSTR_TERMINATOR,
 };
 
@@ -124,45 +124,45 @@ static void pre_ret(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *inst
 
 // TODO / note far jumps, calls and returns are not supported (yet)
 static instr_encode_table_t ret[] = {
-    {OP_ZO, NULL, {0xC3}, MODE_SUPPORT_ALL, {0xC3}, 1, NULL},
-    {OP_I, NULL, {0xC2}, MODE_SUPPORT_ALL, {0xC2}, 1, &pre_ret},
+    {ENC_ZO, NULL, {0xC3}, MODE_SUPPORT_ALL, {0xC3}, 1, NULL},
+    {ENC_I, NULL, {0xC2}, MODE_SUPPORT_ALL, {0xC2}, 1, &pre_ret},
     INSTR_TERMINATOR,
 };
 
 static instr_encode_table_t cmp[] = {INSTR_GENERAL(0x3B, 0x3A, 0x39, 0x38, 0x3D, 0x3C, 7, 0x81, 0x80)};
 
 static instr_encode_table_t push[] = {
-    {OP_M, 6, {0xFF}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
-    {OP_O, NULL, {0x50}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
-    {OP_I, NULL, {0x68}, MODE_SUPPORT_ALL, {0x6A}, 1, &pre_imm},
+    {ENC_M, 6, {0xFF}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
+    {ENC_O, NULL, {0x50}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
+    {ENC_I, NULL, {0x68}, MODE_SUPPORT_ALL, {0x6A}, 1, &pre_imm},
     INSTR_TERMINATOR,
 };
 
 static instr_encode_table_t pop[] = {
-    {OP_M, 0, {0x8F}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
-    {OP_O, NULL, {0x58}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
+    {ENC_M, 0, {0x8F}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
+    {ENC_O, NULL, {0x58}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
     INSTR_TERMINATOR,
 };
 
 static instr_encode_table_t in[] = {{}};
 static instr_encode_table_t out[] = {{}};
 
-static instr_encode_table_t clc[] = {{OP_ZO, NULL, {0xF8}, MODE_SUPPORT_ALL, {0xF8}, 1, NULL}, INSTR_TERMINATOR};
-static instr_encode_table_t stc[] = {{OP_ZO, NULL, {0xF9}, MODE_SUPPORT_ALL, {0xF9}, 1, NULL}, INSTR_TERMINATOR};
-static instr_encode_table_t cli[] = {{OP_ZO, NULL, {0xFA}, MODE_SUPPORT_ALL, {0xFA}, 1, NULL}, INSTR_TERMINATOR};
-static instr_encode_table_t sti[] = {{OP_ZO, NULL, {0xFB}, MODE_SUPPORT_ALL, {0xFB}, 1, NULL}, INSTR_TERMINATOR};
+static instr_encode_table_t clc[] = {{ENC_ZO, NULL, {0xF8}, MODE_SUPPORT_ALL, {0xF8}, 1, NULL}, INSTR_TERMINATOR};
+static instr_encode_table_t stc[] = {{ENC_ZO, NULL, {0xF9}, MODE_SUPPORT_ALL, {0xF9}, 1, NULL}, INSTR_TERMINATOR};
+static instr_encode_table_t cli[] = {{ENC_ZO, NULL, {0xFA}, MODE_SUPPORT_ALL, {0xFA}, 1, NULL}, INSTR_TERMINATOR};
+static instr_encode_table_t sti[] = {{ENC_ZO, NULL, {0xFB}, MODE_SUPPORT_ALL, {0xFB}, 1, NULL}, INSTR_TERMINATOR};
 
-static instr_encode_table_t nop[] = {{OP_ZO, NULL, {0x90}, MODE_SUPPORT_ALL, {0x90}, 1, NULL}, INSTR_TERMINATOR};
-static instr_encode_table_t hlt[] = {{OP_ZO, NULL, {0xF4}, MODE_SUPPORT_ALL, {0xF4}, 1, NULL}, INSTR_TERMINATOR};
+static instr_encode_table_t nop[] = {{ENC_ZO, NULL, {0x90}, MODE_SUPPORT_ALL, {0x90}, 1, NULL}, INSTR_TERMINATOR};
+static instr_encode_table_t hlt[] = {{ENC_ZO, NULL, {0xF4}, MODE_SUPPORT_ALL, {0xF4}, 1, NULL}, INSTR_TERMINATOR};
 
 static void pre_int(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
   if (op_sizeof(op_arr[0].type) != 8)
     err("Invalid operand size for INT instruction.");
 }
 
-static instr_encode_table_t _int[] = {{OP_I, NULL, {0xCD}, MODE_SUPPORT_ALL, {0xCD}, 1, &pre_int}, INSTR_TERMINATOR};
+static instr_encode_table_t _int[] = {{ENC_I, NULL, {0xCD}, MODE_SUPPORT_ALL, {0xCD}, 1, &pre_int}, INSTR_TERMINATOR};
 static instr_encode_table_t syscall[] = {
-    {OP_ZO, NULL, {0x0F, 0x05}, MODE_SUPPORT_64BIT, {0x00, 0x00}, 2, &same_operand_sizes},
+    {ENC_ZO, NULL, {0x0F, 0x05}, MODE_SUPPORT_64BIT, {0x00, 0x00}, 2, &same_operand_sizes},
     INSTR_TERMINATOR,
 };
 
@@ -190,8 +190,8 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
 
   enum enc_ident ident = op_ident_identify(operand_list);
   if (instr.instr == INSTR_MOV) {
-    if (ident == OP_MI) ident = OP_OI;
-    if (ident == OP_I) ident = OP_O;
+    if (ident == ENC_MI) ident = ENC_OI;
+    if (ident == ENC_I) ident = ENC_O;
   }
 
   unsigned int j = 0;

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -208,7 +208,3 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
   return INSTR_TERMINATOR; // aka empty
 }
 
-instr_encoder_t instr_encode_func(enum enc_ident input) {
-  instr_encoder_t lookup[] = {&mr, &rm, &oi, &mi, &i, &m, &zo, &d, &o};
-  return lookup[(size_t)input];
-}

--- a/libjas/operand.cpp
+++ b/libjas/operand.cpp
@@ -58,20 +58,20 @@ static op_ident_hash_t op_hash(enum operands input) {
 
 namespace op {
   static std::unordered_map<uint32_t, enum enc_ident> lookup = {
-      {__combine__(OP_HASH_R, OP_HASH_R, OP_HASH_NONE, OP_HASH_NONE), OP_MR},
-      {__combine__(OP_HASH_M, OP_HASH_R, OP_HASH_NONE, OP_HASH_NONE), OP_MR},
+      {__combine__(OP_HASH_R, OP_HASH_R, OP_HASH_NONE, OP_HASH_NONE), ENC_MR},
+      {__combine__(OP_HASH_M, OP_HASH_R, OP_HASH_NONE, OP_HASH_NONE), ENC_MR},
 
-      {__combine__(OP_HASH_R, OP_HASH_M, OP_HASH_NONE, OP_HASH_NONE), OP_RM},
+      {__combine__(OP_HASH_R, OP_HASH_M, OP_HASH_NONE, OP_HASH_NONE), ENC_RM},
 
-      {__combine__(OP_HASH_R, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE), OP_MI},
-      {__combine__(OP_HASH_M, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE), OP_MI},
+      {__combine__(OP_HASH_R, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE), ENC_MI},
+      {__combine__(OP_HASH_M, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE), ENC_MI},
 
-      {__combine__(OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), OP_ZO},
-      {__combine__(OP_HASH_ACC, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE), OP_I},
-      {__combine__(OP_HASH_REL, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), OP_D},
+      {__combine__(OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), ENC_ZO},
+      {__combine__(OP_HASH_ACC, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE), ENC_I},
+      {__combine__(OP_HASH_REL, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), ENC_D},
 
-      {__combine__(OP_HASH_R, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), OP_M},
-      {__combine__(OP_HASH_M, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), OP_M},
+      {__combine__(OP_HASH_R, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), ENC_M},
+      {__combine__(OP_HASH_M, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), ENC_M},
   };
 }
 extern "C" enum enc_ident op_ident_identify(enum operands *input) {

--- a/tests/operand.c
+++ b/tests/operand.c
@@ -47,8 +47,8 @@ Test(operand, ident_identify) {
   const enum operands input[] = {OP_R8, OP_R16, OP_NULL, OP_NULL};
   const enum operands input2[] = {OP_R8, OP_M16, OP_NULL, OP_NULL};
 
-  assert_eq(op_ident_identify(input), OP_MR);
-  assert_eq(op_ident_identify(input2), OP_RM);
+  assert_eq(op_ident_identify(input), ENC_MR);
+  assert_eq(op_ident_identify(input2), ENC_RM);
 }
 
 Test(operand, modrm_mode) {


### PR DESCRIPTION
This Pull, the encoder module received minor updates and changes including function and enum renaming as well as minor refactoring works carried out. Notably, the lookup table for encoders has been moved from the instruction module over to the encoder module and **all encoder functions must be call through this function**, encoder functions shall not be called directly. More details appear in the commit logs