### PR TITLE
Instruction table refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,9 @@ opcode, and support status in different operating modes. Below is an example of 
 
 ```c
 #include <jas.h>
+#include <stdbool.h>
 
-static instr_encode_table_t new_ent = {
+DEFINE_TAB(new_ent) = {
   .ident                 = OP_MR, 
   .opcode_ext            = NULL, 
   .opcode                = {0xff},
@@ -74,6 +75,7 @@ static instr_encode_table_t new_ent = {
   .byte_instr_opcode     = {0xfa},
   .opcode_size           = 1,
   .pre                   = NULL,
+  .has_byte_opcode       = true,
 };
 
 // `new_ent` will be added to an array of different instruction identities.

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -104,6 +104,7 @@ struct instr_encode_table {
   uint8_t byte_instr_opcode[3]; /* 8 bit opcode fallback of the instruction */
   uint8_t opcode_size;          /* Size of the opcode (max. 3 bytes)*/
   pre_encoder_t pre;            /* Pre-encoder processor function (Optional, null if not applicable) */
+  bool has_byte_opcode;         /* If the instruction encoder table has a byte instruction opcode */
 };
 
 /**
@@ -126,6 +127,7 @@ typedef struct {
     .byte_instr_opcode = {NULL}, \
     .opcode_size = NULL,         \
     .pre = NULL,                 \
+    .has_byte_opcode = false     \
   }
 
 #define INSTR_NULL \

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -69,10 +69,10 @@ static void pre_lea(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *inst
 // clang-format off
 
 #define GENERIC(rm, rm_byte, mr, mr_byte,i, i_byte, mi_ext, mi, mi_byte)  \
-      {ENC_MR, NULL, {mr}, MODE_SUPPORT_ALL, {mr_byte}, 1, &same_operand_sizes},        \
       {ENC_RM, NULL, {rm}, MODE_SUPPORT_ALL, {rm_byte}, 1, &same_operand_sizes},        \
-      {ENC_MI, mi_ext, {mi}, MODE_SUPPORT_ALL, {mi_byte}, 1, &pre_imm},          \
+      {ENC_MR, NULL, {mr}, MODE_SUPPORT_ALL, {mr_byte}, 1, &same_operand_sizes},        \
       {ENC_I, NULL, {i}, MODE_SUPPORT_ALL, {i_byte}, 1, &pre_imm},               \
+      {ENC_MI, mi_ext, {mi}, MODE_SUPPORT_ALL, {mi_byte}, 1, &pre_imm},          \
       INSTR_TERMINATOR,
 
 // clang-format on

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -47,11 +47,13 @@ static void pre_imm(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *inst
   }
 }
 
+#define ZERO_EXT 0b10000000
+
 static instr_encode_table_t mov[] = {
     {ENC_MR, NULL, {0x89}, MODE_SUPPORT_ALL, {0x88}, 1, &same_operand_sizes},
     {ENC_RM, NULL, {0x8B}, MODE_SUPPORT_ALL, {0x8A}, 1, &same_operand_sizes},
     {ENC_OI, NULL, {0xB8}, MODE_SUPPORT_ALL, {0xB0}, 1, &same_operand_sizes},
-    {ENC_MI, 0b10000000, {0xC7}, MODE_SUPPORT_ALL, {0xC6}, 1, &pre_imm},
+    {ENC_MI, ZERO_EXT, {0xC7}, MODE_SUPPORT_ALL, {0xC6}, 1, &pre_imm},
 
     INSTR_TERMINATOR,
 };
@@ -66,7 +68,7 @@ static void pre_lea(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *inst
 
 // clang-format off
 
-#define INSTR_GENERAL(rm, rm_byte, mr, mr_byte,i, i_byte, mi_ext, mi, mi_byte)  \
+#define GENERIC(rm, rm_byte, mr, mr_byte,i, i_byte, mi_ext, mi, mi_byte)  \
       {ENC_MR, NULL, {mr}, MODE_SUPPORT_ALL, {mr_byte}, 1, &same_operand_sizes},        \
       {ENC_RM, NULL, {rm}, MODE_SUPPORT_ALL, {rm_byte}, 1, &same_operand_sizes},        \
       {ENC_MI, mi_ext, {mi}, MODE_SUPPORT_ALL, {mi_byte}, 1, &pre_imm},          \
@@ -77,16 +79,16 @@ static void pre_lea(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *inst
 
 static instr_encode_table_t lea[] = {{ENC_RM, NULL, {0x8D}, MODE_SUPPORT_ALL, {0x8D}, 1, &pre_lea}, INSTR_TERMINATOR};
 
-static instr_encode_table_t add[] = {INSTR_GENERAL(0x03, 0x02, 0x01, 0x00, 0x03, 0x02, 0b10000000, 0x81, 0x80)};
-static instr_encode_table_t sub[] = {INSTR_GENERAL(0x2B, 0x2A, 0x28, 0x29, 0x2C, 0x2D, 5, 0x81, 0x80)};
+static instr_encode_table_t add[] = {GENERIC(0x03, 0x02, 0x01, 0x00, 0x03, 0x02, ZERO_EXT, 0x81, 0x80)};
+static instr_encode_table_t sub[] = {GENERIC(0x2B, 0x2A, 0x28, 0x29, 0x2C, 0x2D, 5, 0x81, 0x80)};
 static instr_encode_table_t mul[] = {{ENC_M, 4, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
 static instr_encode_table_t div[] = {{ENC_M, 6, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes}, INSTR_TERMINATOR};
 
 // Note all or, and and xor instructions have a imm8 which is not supported
 
-static instr_encode_table_t and[] = {INSTR_GENERAL(0x23, 0x22, 0x21, 0x20, 0x25, 0x24, 4, 0x81, 0x80)};
-static instr_encode_table_t or [] = {INSTR_GENERAL(0x0B, 0x0A, 0x09, 0x08, 0x0D, 0x0C, 1, 0x81, 0x80)};
-static instr_encode_table_t xor [] = {INSTR_GENERAL(0x33, 0x32, 0x31, 0x30, 0x35, 0x34, 6, 0x81, 0x80)};
+static instr_encode_table_t and[] = {GENERIC(0x23, 0x22, 0x21, 0x20, 0x25, 0x24, 4, 0x81, 0x80)};
+static instr_encode_table_t or [] = {GENERIC(0x0B, 0x0A, 0x09, 0x08, 0x0D, 0x0C, 1, 0x81, 0x80)};
+static instr_encode_table_t xor [] = {GENERIC(0x33, 0x32, 0x31, 0x30, 0x35, 0x34, 6, 0x81, 0x80)};
 
 // ---
 
@@ -129,7 +131,7 @@ static instr_encode_table_t ret[] = {
     INSTR_TERMINATOR,
 };
 
-static instr_encode_table_t cmp[] = {INSTR_GENERAL(0x3B, 0x3A, 0x39, 0x38, 0x3D, 0x3C, 7, 0x81, 0x80)};
+static instr_encode_table_t cmp[] = {GENERIC(0x3B, 0x3A, 0x39, 0x38, 0x3D, 0x3C, 7, 0x81, 0x80)};
 
 static instr_encode_table_t push[] = {
     {ENC_M, 6, {0xFF}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -50,10 +50,10 @@ static void pre_imm(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *inst
 #define ZERO_EXT 0b10000000
 
 static instr_encode_table_t mov[] = {
-    {ENC_MR, NULL, {0x89}, MODE_SUPPORT_ALL, {0x88}, 1, &same_operand_sizes},
-    {ENC_RM, NULL, {0x8B}, MODE_SUPPORT_ALL, {0x8A}, 1, &same_operand_sizes},
+    {ENC_MR, NULL, {0x89}, MODE_SUPPORT_ALL, {0x88}, 1, &same_operand_sizes, true},
+    {ENC_RM, NULL, {0x8B}, MODE_SUPPORT_ALL, {0x8A}, 1, &same_operand_sizes, true},
     {ENC_OI, NULL, {0xB8}, MODE_SUPPORT_ALL, {0xB0}, 1, &same_operand_sizes},
-    {ENC_MI, ZERO_EXT, {0xC7}, MODE_SUPPORT_ALL, {0xC6}, 1, &pre_imm},
+    {ENC_MI, ZERO_EXT, {0xC7}, MODE_SUPPORT_ALL, {0xC6}, 1, &pre_imm, true},
 
     INSTR_TERMINATOR,
 };
@@ -69,7 +69,7 @@ static void pre_lea(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *inst
 // clang-format off
 
 #define GENERIC(rm, rm_byte, mr, mr_byte,i, i_byte, mi_ext, mi, mi_byte)  \
-      {ENC_RM, NULL, {rm}, MODE_SUPPORT_ALL, {rm_byte}, 1, &same_operand_sizes},        \
+     {ENC_RM, NULL, {rm}, MODE_SUPPORT_ALL, {rm_byte}, 1, &same_operand_sizes},        \
       {ENC_MR, NULL, {mr}, MODE_SUPPORT_ALL, {mr_byte}, 1, &same_operand_sizes},        \
       {ENC_I, NULL, {i}, MODE_SUPPORT_ALL, {i_byte}, 1, &pre_imm},               \
       {ENC_MI, mi_ext, {mi}, MODE_SUPPORT_ALL, {mi_byte}, 1, &pre_imm},          \
@@ -104,7 +104,7 @@ static void pre_jcc_no_byte(operand_t *op_arr, buffer_t *buf, instr_encode_table
 
 static instr_encode_table_t jmp[] = {
     {ENC_D, NULL, {0xE9}, MODE_SUPPORT_ALL, {0xEB}, 1, NULL},
-    {ENC_M, 4, {0xFF}, MODE_SUPPORT_ALL, {0x90}, 1, &pre_imm},
+    {ENC_M, 4, {0xFF}, MODE_SUPPORT_ALL, {NULL}, 1, &pre_imm, false},
     INSTR_TERMINATOR,
 };
 
@@ -115,7 +115,7 @@ static instr_encode_table_t jnz[] = {{ENC_D, NULL, {0x0f, 0x85}, MODE_SUPPORT_AL
 
 static instr_encode_table_t call[] = {
     {ENC_D, NULL, {0xE8}, MODE_SUPPORT_ALL, {0xEB}, 1, NULL},
-    {ENC_M, 2, {0xFF}, MODE_SUPPORT_ALL, {0x90}, 1, &pre_imm},
+    {ENC_M, 2, {0xFF}, MODE_SUPPORT_ALL, {NULL}, 1, &pre_imm, false},
     INSTR_TERMINATOR,
 };
 
@@ -134,15 +134,15 @@ static instr_encode_table_t ret[] = {
 static instr_encode_table_t cmp[] = {GENERIC(0x3B, 0x3A, 0x39, 0x38, 0x3D, 0x3C, 7, 0x81, 0x80)};
 
 static instr_encode_table_t push[] = {
-    {ENC_M, 6, {0xFF}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
-    {ENC_O, NULL, {0x50}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
-    {ENC_I, NULL, {0x68}, MODE_SUPPORT_ALL, {0x6A}, 1, &pre_imm},
+    {ENC_M, 6, {0xFF}, MODE_SUPPORT_ALL, NULL, 1, NULL, false},
+    {ENC_O, NULL, {0x50}, MODE_SUPPORT_ALL, NULL, 1, NULL, false},
+    {ENC_I, NULL, {0x68}, MODE_SUPPORT_ALL, {0x6A}, 1, &pre_imm, false},
     INSTR_TERMINATOR,
 };
 
 static instr_encode_table_t pop[] = {
-    {ENC_M, 0, {0x8F}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
-    {ENC_O, NULL, {0x58}, MODE_SUPPORT_ALL, {0x90}, 1, NULL},
+    {ENC_M, 0, {0x8F}, MODE_SUPPORT_ALL, NULL, 1, NULL, false},
+    {ENC_O, NULL, {0x58}, MODE_SUPPORT_ALL, NULL, 1, NULL, false},
     INSTR_TERMINATOR,
 };
 
@@ -154,7 +154,7 @@ static instr_encode_table_t stc[] = {{ENC_ZO, NULL, {0xF9}, MODE_SUPPORT_ALL, {0
 static instr_encode_table_t cli[] = {{ENC_ZO, NULL, {0xFA}, MODE_SUPPORT_ALL, {0xFA}, 1, NULL}, INSTR_TERMINATOR};
 static instr_encode_table_t sti[] = {{ENC_ZO, NULL, {0xFB}, MODE_SUPPORT_ALL, {0xFB}, 1, NULL}, INSTR_TERMINATOR};
 
-static instr_encode_table_t nop[] = {{ENC_ZO, NULL, {0x90}, MODE_SUPPORT_ALL, {0x90}, 1, NULL}, INSTR_TERMINATOR};
+static instr_encode_table_t nop[] = {{ENC_ZO, {0x90}, NULL, MODE_SUPPORT_ALL, NULL, 1, NULL, false}, INSTR_TERMINATOR};
 static instr_encode_table_t hlt[] = {{ENC_ZO, NULL, {0xF4}, MODE_SUPPORT_ALL, {0xF4}, 1, NULL}, INSTR_TERMINATOR};
 
 static void pre_int(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -195,7 +195,7 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
     if (ident == ENC_MI) ident = ENC_OI;
     if (ident == ENC_I) ident = ENC_O;
   }
-  for (uint8_t j = 0; j < sizeof(CURR_TABLE) / sizeof(instr_encode_table_t); j++)
+  for (uint8_t j = 0; CURR_TABLE.opcode_size; j++)
     if (CURR_TABLE.ident == ident) return CURR_TABLE;
 
   // fall-through; no corresponding instruction opcode found

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -178,33 +178,25 @@ instr_encode_table_t *instr_table[] =
         in, out, clc, stc, cli, sti, nop, hlt, _int, syscall,
     };
 
-// clang-format on
 
 #define CURR_TABLE instr_table[instr.instr][j]
 
 instr_encode_table_t instr_get_tab(instruction_t instr) {
   if (IS_LABEL(instr)) return INSTR_TERMINATOR; // aka empty
   const enum operands operand_list[4] = {
-      instr.operands[0].type,
-      instr.operands[1].type,
-      instr.operands[2].type,
-      instr.operands[3].type,
+      instr.operands[0].type, instr.operands[1].type,
+      instr.operands[2].type, instr.operands[3].type,
   };
+
+  // clang-format on
 
   enum enc_ident ident = op_ident_identify(operand_list);
   if (instr.instr == INSTR_MOV) {
     if (ident == ENC_MI) ident = ENC_OI;
     if (ident == ENC_I) ident = ENC_O;
   }
-
-  unsigned int j = 0;
-  while (CURR_TABLE.opcode_size != 0) {
-    if (CURR_TABLE.ident == ident) {
-      return CURR_TABLE;
-      break;
-    }
-    j++;
-  }
+  for (uint8_t j = 0; j < sizeof(CURR_TABLE) / sizeof(instr_encode_table_t); j++)
+    if (CURR_TABLE.ident == ident) return CURR_TABLE;
 
   // fall-through; no corresponding instruction opcode found
   err("No corrsponding instruction opcode found.");


### PR DESCRIPTION
This pull request describes several changes that has allowed for better readability in the very crowded and complex `instruction.c` file (The file that has described the instruction encoder reference tables). This branch has not only reduced redundant and repetitive code blocks but has also added redundancy and measures to prevent incorrect encoding. Check the commit logs for more information. This is just a short description for the log. ;)

Alvin.