### PR TITLE
Added `op_write_opcode()` function

### DIFF
--- a/libjas/include/operand.h
+++ b/libjas/include/operand.h
@@ -196,6 +196,25 @@ uint8_t op_sizeof(enum operands input);
  */
 operand_t op_construct_operand(enum operands type, size_t offset, void *data);
 
+/**
+ * Function for returning the opcode of the instruction based
+ * on the instruction encoder table provided in the function
+ * arguments as well as if a byte opcode is provided in the
+ * the encoder table.
+ *
+ * @param op_arr The operand array to base the opcode from
+ * @param instr_ref The instruction reference table
+ * @return The opcode of the instruction
+ *
+ * You can literally wrap this into a buffer write function
+ * to quickly and easily write in the opcode like as shown:
+ *
+ *  buf_write(buf, op_write_opcode(<operands>, <encoder table>), <opcode size>);
+ *
+ * @see buffer.h
+ */
+uint8_t *op_write_opcode(operand_t *op_arr, instr_encode_table_t *instr_ref);
+
 #define OP_NONE      \
   (operand_t) {      \
     .data = NULL,    \

--- a/tests/operand.c
+++ b/tests/operand.c
@@ -1,6 +1,7 @@
 #include "operand.h"
 #include "buffer.h"
 #include "encoder.h"
+#include "instruction.h"
 #include "rex.h"
 #include "test.h"
 
@@ -68,6 +69,18 @@ Test(operand, modrm_mode) {
   }
 }
 
+Test(operand, write_opcode) {
+  const operand_t op_arr[] = {r64, imm64, OP_NONE, OP_NONE};
+  const instr_encode_table_t instr_ref = {ENC_MI, 0, {0xC7}, MODE_SUPPORT_ALL, {0xC6}, 1, NULL, true};
+
+  uint8_t *out = op_write_opcode(op_arr, &instr_ref);
+  assert_eq(out, instr_ref.opcode);
+
+  const operand_t op_arr_byte[] = {r8, imm8, OP_NONE, OP_NONE};
+  out = op_write_opcode(op_arr_byte, &instr_ref);
+  assert_eq(out, instr_ref.byte_instr_opcode);
+}
+
 int main(void) {
   TestSuite(operand);
 
@@ -75,6 +88,7 @@ int main(void) {
   RunTest(operand, construct_operand);
   RunTest(operand, ident_identify);
   RunTest(operand, modrm_mode);
+  RunTest(operand, write_opcode);
 
   return 0;
 }


### PR DESCRIPTION
This commit has added the `op_write_opcode` funciton, this funciton intends to replace the old and weird `OP_OPCODE_HELPER` macro that attempts to write a opcode using macro functions and without much consideration about other variable condiitons.