### PR TITLE
Revised `op_write_opcode` function

### DIFF
--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -67,12 +67,13 @@ uint8_t op_sizeof(enum operands input) {
 /* Instructions containing a byte-sized operand uses the byte opcode (see. 4-136 Vol. 2B, MOVZX—Move With Zero-Extend) */
 uint8_t *op_write_opcode(operand_t *op_arr, instr_encode_table_t *instr_ref) {
   if (!instr_ref->has_byte_opcode) return instr_ref->opcode;
-
   for (uint8_t i = 0; i < 4; i++) {
     if (op_arr[i].type == OP_NULL) break;
     if (op_byte(op_arr[i].type)) return instr_ref->byte_instr_opcode;
     continue;
   }
+
+  return instr_ref->opcode;
 }
 
 void op_write_prefix(buffer_t *buf, const operand_t *op_arr, enum modes mode) {

--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -64,27 +64,15 @@ uint8_t op_sizeof(enum operands input) {
   return 0;
 }
 
+/* Instructions containing a byte-sized operand uses the byte opcode (see. 4-136 Vol. 2B, MOVZX—Move With Zero-Extend) */
 uint8_t *op_write_opcode(operand_t *op_arr, instr_encode_table_t *instr_ref) {
   if (!instr_ref->has_byte_opcode) return instr_ref->opcode;
 
-  // According to Oracle's <x86 Assembly Language Reference Manual>
-  // (Yeah seriously - Oracle has a x86 Assembly Language Reference Manual)
-  // Only when *BOTH* operands are byte-sized, the opcode will also be byte-sized
-  // So, wel'll check if they are *BOTH* byte sized then write that.
-
-  const uint8_t reference = op_sizeof(op_arr[0].type);
-  const uint8_t sizes[] =
-      {reference, op_sizeof(op_arr[1].type),
-       op_sizeof(op_arr[2].type), op_sizeof(op_arr[3].type)};
-
-  bool sizes_are_byte = reference == 8;
-  for (unsigned char i = 0; i < 4; i++) {
+  for (uint8_t i = 0; i < 4; i++) {
     if (op_arr[i].type == OP_NULL) break;
-    if (sizes[i] != 8 && sizes_are_byte) sizes_are_byte = false;
+    if (op_byte(op_arr[i].type)) return instr_ref->byte_instr_opcode;
+    continue;
   }
-
-  if (sizes_are_byte) return instr_ref->byte_instr_opcode;
-  return instr_ref->opcode;
 }
 
 void op_write_prefix(buffer_t *buf, const operand_t *op_arr, enum modes mode) {


### PR DESCRIPTION
Happy new year, this pull has revised the `op_write_opcode` function, which was previously mis-interpreted. According to the Intel x86 docs, a instruction **including** a byte-sized operand **MUST** use the byte instruction opcode. This is demonstrated in the MOVZX instruction's docs on 4-136 Vol. 2B where a seperate opcode is used with `r/m8`.