### PR TITLE
Added support for MOVZX

### DIFF
--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -82,6 +82,7 @@ enum instructions {
   INSTR_HLT,
   INSTR_INT,
   INSTR_SYSCALL,
+  INSTR_MOVZX,
 
   INSTR_DUMMY,
 

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -169,13 +169,21 @@ DEFINE_TAB(syscall) = {
     INSTR_TERMINATOR,
 };
 
+static void pre_movzx(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+  if (op_sizeof(op_arr[1].type) < 16)
+    err("Invalid operand size for MOVZX instruction");
+}
+
+DEFINE_TAB(movzx) = {{ENC_RM, NULL, {0x0F, 0xB7}, MODE_SUPPORT_ALL, {0x0F, 0xB6}, 2, &pre_movzx}, INSTR_TERMINATOR};
+
 // clang-format off
 
 instr_encode_table_t *instr_table[] =
     {
         mov, lea, add, sub, mul, div, and, or, xor, _not, inc,
         dec, jmp, je, jne, jz, jnz, call, ret, cmp, push, pop,
-        in, out, clc, stc, cli, sti, nop, hlt, _int, syscall,
+        in, out, clc, stc, cli, sti, nop, hlt, _int, syscall, 
+        movzx,
     };
 
 


### PR DESCRIPTION
This pull added support for the MOVZX instruction (Move with zero- extend). Although this pull have not added the required unit tests for this instruction (None of the instruction other than `mov` for a matter of fact), this pull has added the MOVZX instruction's co- rrisponding encoder table as well as its enum entry in `instruction.h`