### PR TITLE
Fix mr rm ident clash

### DIFF
--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -82,6 +82,7 @@ enum instructions {
   INSTR_HLT,
   INSTR_INT,
   INSTR_SYSCALL,
+  INSTR_MOVZX,
 
   INSTR_DUMMY,
 

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -199,10 +199,12 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
   // clang-format on
 
   enum enc_ident ident = op_ident_identify(operand_list);
+  if (ident == ENC_MR && op_r(operand_list[0])) ident = ENC_RM;
   if (instr.instr == INSTR_MOV) {
     if (ident == ENC_MI) ident = ENC_OI;
     if (ident == ENC_I) ident = ENC_O;
   }
+
   for (uint8_t j = 0; CURR_TABLE.opcode_size; j++)
     if (CURR_TABLE.ident == ident) return CURR_TABLE;
 

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -169,13 +169,21 @@ DEFINE_TAB(syscall) = {
     INSTR_TERMINATOR,
 };
 
+static void pre_movzx(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+  if (op_sizeof(op_arr[1].type) < 16)
+    err("Invalid operand size for MOVZX instruction");
+}
+
+DEFINE_TAB(movzx) = {{ENC_RM, NULL, {0x0F, 0xB7}, MODE_SUPPORT_ALL, {0x0F, 0xB6}, 2, &pre_movzx}, INSTR_TERMINATOR};
+
 // clang-format off
 
 instr_encode_table_t *instr_table[] =
     {
         mov, lea, add, sub, mul, div, and, or, xor, _not, inc,
         dec, jmp, je, jne, jz, jnz, call, ret, cmp, push, pop,
-        in, out, clc, stc, cli, sti, nop, hlt, _int, syscall,
+        in, out, clc, stc, cli, sti, nop, hlt, _int, syscall, 
+        movzx,
     };
 
 


### PR DESCRIPTION
The `MR` and `RM` identies are very very similar, they both use the same operand type - namely registers and also what Intel refers as `m` (memory) locations. Due to the `MR` identity being put before the `RM` identity in `encoder.h`'s `enum enc_ident` enumeration, the assembler has always had a tendency to use the `MR` encoder enum identity when a register and memory location is expressed. This is very problematic when the assembler matches the operand types with some instructions that *don't support* the `MR` identity, causing an opcode error to be thrown.

Therefore to prevent the confusing behavior, we'll need to manually override this behavior by *manually* adding a if condition to change it when able.