### PR TITLE
Fix readme example that isn't proper C

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ First of all, install/link against the binary releases [here](https://github.com
 #include <stdlib.h>
 
 int main(void) {
-  instruction_t instr[] = (instruction_t[]) {
+  instruction_t instr[] = {
       (instruction_t){
           .instr = INSTR_MOV,
           .operands = (operand_t[]){


### PR DESCRIPTION
` instruction_t instr[] = (instruction_t[]) {`

This line instantly caught my eye. This isn't proper C. If this compiles, it's because of a GNU extension. The true C way is simpler:

` instruction_t instr[] = {`