### PR TITLE
Fix encoder clash

### DIFF
--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -200,10 +200,9 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
 
   enum enc_ident ident = op_ident_identify(operand_list);
   if (ident == ENC_MR && op_r(operand_list[0])) ident = ENC_RM;
-  if (instr.instr == INSTR_MOV) {
+  // TODO Edge case for MOV instruction - Work on in future
+  if (instr.instr == INSTR_MOV)
     if (ident == ENC_MI) ident = ENC_OI;
-    if (ident == ENC_I) ident = ENC_O;
-  }
 
   for (uint8_t j = 0; CURR_TABLE.opcode_size; j++)
     if (CURR_TABLE.ident == ident) return CURR_TABLE;

--- a/libjas/operand.cpp
+++ b/libjas/operand.cpp
@@ -67,7 +67,8 @@ namespace op {
       {__combine__(OP_HASH_M, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE), ENC_MI},
 
       {__combine__(OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), ENC_ZO},
-      {__combine__(OP_HASH_ACC, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE), ENC_I},
+      {__combine__(OP_HASH_ACC, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE), ENC_O},
+      {__combine__(OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), ENC_I},
       {__combine__(OP_HASH_REL, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), ENC_D},
 
       {__combine__(OP_HASH_R, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE), ENC_M},


### PR DESCRIPTION
This pull has fixed the strange encoders clash between the O and I
encoder functions, previously the encoders O and I were both to be
thought as one `imm` (immediate value) operand on the first operand
location.

Upon futher review, it was found that the I operand encoder function
identity consists of a `imm` operand **exclusively** and does not
contain any more oprands. Contary to the I identity, the O identity
**ALSO** contains a **accumulator** as the first operand and a `imm`
**following** the **accumulator** instead.
