### PR TITLE
Added support for MOVSX

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -31,7 +31,7 @@ https://docs.google.com/document/d/1bm9lxVyAk2qogOF9ujERyRcSwXkpKxLW8IWVU8FuMyE/
 More instructions:
 Data Movement Instructions
 XCHG: Exchange data between registers or memory.
-MOVSX/MOVZX: Move with sign/zero extension.
+MOVSX/MOVZX: Move with sign/zero extension. - ✅
 BSWAP: Byte swap (useful for endian conversion).
 CMOVcc: Conditional move based on flags (e.g., CMOVZ, CMOVNZ).
 Arithmetic and Logic Instructions

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -83,6 +83,7 @@ enum instructions {
   INSTR_INT,
   INSTR_SYSCALL,
   INSTR_MOVZX,
+  INSTR_MOVSX,
 
   INSTR_DUMMY,
 

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -176,12 +176,13 @@ DEFINE_TAB(syscall) = {
     INSTR_TERMINATOR,
 };
 
-static void pre_movzx(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+static void pre_small_operands(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
   if (op_sizeof(op_arr[1].type) < 16)
     err("Invalid operand size for MOVZX instruction");
 }
 
-DEFINE_TAB(movzx) = {{ENC_RM, NULL, {0x0F, 0xB7}, MODE_SUPPORT_ALL, {0x0F, 0xB6}, 2, &pre_movzx, true}, INSTR_TERMINATOR};
+DEFINE_TAB(movzx) = {{ENC_RM, NULL, {0x0F, 0xB7}, MODE_SUPPORT_ALL, {0x0F, 0xB6}, 2, &pre_small_operands, true}, INSTR_TERMINATOR};
+DEFINE_TAB(movsx) = {{ENC_RM, NULL, {0x0F, 0xBF}, MODE_SUPPORT_ALL, {0x0F, 0xBE}, 2, &pre_small_operands, true}, INSTR_TERMINATOR};
 
 // clang-format off
 
@@ -190,7 +191,7 @@ instr_encode_table_t *instr_table[] =
         mov, lea, add, sub, mul, div, and, or, xor, _not, inc,
         dec, jmp, je, jne, jz, jnz, call, ret, cmp, push, pop,
         in, out, clc, stc, cli, sti, nop, hlt, _int, syscall, 
-        movzx,
+        movzx, movsx,
     };
 
 


### PR DESCRIPTION
This pull has added complete support for the MOVSX (Move with sign extension) instruction, since this instruction exhibits very similar encodings to the previously implemented MOVSX instruction, many encoding functionality and encoder tables can be *shared* (Such as pre-processors and opcods)

Although this pull is listed as only adding support for the MOVSX instruction, this pull has also renamed the `pre_movzx` pre-proces- or function `pre_small_operands` to better encapsulate its behavior and allowing cross-usage to other instruction enocder tables.