### PR TITLE
Fixed error message

### DIFF
--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -178,7 +178,7 @@ DEFINE_TAB(syscall) = {
 
 static void pre_small_operands(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
   if (op_sizeof(op_arr[1].type) < 16)
-    err("Invalid operand size for MOVZX instruction");
+    err("Invalid operand size for MOVZX/MOVSX instruction");
 }
 
 DEFINE_TAB(movzx) = {{ENC_RM, NULL, {0x0F, 0xB7}, MODE_SUPPORT_ALL, {0x0F, 0xB6}, 2, &pre_small_operands, true}, INSTR_TERMINATOR};


### PR DESCRIPTION
In the previous pull - #32 where the `pre_movzx` pre-processor was renamed to `pre_small_operand_sizes`, the error message was not changed and remained to shown as a "MOVZX" instruction fault as per the patch. This pull has corrected the error message to point to both the MOVZX and MOVSX instructions instead.