### PR TITLE
Added case for `NULL` instructions

### DIFF
--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -205,6 +205,7 @@ instr_encode_table_t *instr_table[] =
 #define CURR_TABLE instr_table[instr.instr][j]
 
 instr_encode_table_t instr_get_tab(instruction_t instr) {
+  if (instr.instr == NULL && instr.operands == NULL) return INSTR_TERMINATOR;
   if (IS_LABEL(instr)) return INSTR_TERMINATOR; // aka empty
   const enum operands operand_list[4] = {
       instr.operands[0].type, instr.operands[1].type,


### PR DESCRIPTION
This pull has addded a "edge case" for the `INSTR_NULL` cases that may be passed into the `instr_get_tab` funciton. Further testing has found that this function may be problematic and force segmentation faults when faced with a `NULL` value in either the operands or `instr` member. Now, this function will intentionally skip any `NULL` or `INST- R_NULL` values.