### PR TITLE
Added label member support to `op_construct_operand`

### DIFF
--- a/libjas/include/operand.h
+++ b/libjas/include/operand.h
@@ -189,12 +189,13 @@ uint8_t op_sizeof(enum operands input);
  * @param type The type of the operand
  * @param offset The offset of the operand
  * @param data The data of the operand
+ * @param label The name of the referenced label (if applicable)
  * @return The constructed operand struct
  *
  * @note Operands and parameter types are based on `operand_t`
  * @see `operand_t`
  */
-operand_t op_construct_operand(enum operands type, size_t offset, void *data);
+operand_t op_construct_operand(enum operands type, size_t offset, void *data, char *label);
 
 /**
  * Function for returning the opcode of the instruction based

--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -160,10 +160,11 @@ void op_write_prefix(buffer_t *buf, const operand_t *op_arr, enum modes mode) {
     buf_write_byte(buf, rex);
 }
 
-operand_t op_construct_operand(enum operands type, size_t offset, void *data) {
+operand_t op_construct_operand(enum operands type, size_t offset, void *data, char *label) {
   return (operand_t){
       .type = type,
       .offset = offset,
       .data = data,
+      .label = label,
   };
 }

--- a/tests/operand.c
+++ b/tests/operand.c
@@ -37,7 +37,7 @@ Test(operand, write_prefix) {
 }
 
 Test(operand, construct_operand) {
-  const operand_t byte = op_construct_operand(OP_IMM8, 0, &(unsigned char){0xFF});
+  const operand_t byte = op_construct_operand(OP_IMM8, 0, &(unsigned char){0xFF}, "");
 
   assert_eq(byte.type, OP_IMM8);
   assert_eq(byte.offset, 0);
@@ -57,11 +57,11 @@ Test(operand, modrm_mode) {
     operand_t operand;
     int expected_mode;
   } test_cases[] = {
-      {op_construct_operand(OP_M64, 0, &(enum registers){REG_RIP}), OP_MODRM_INDIRECT},
-      {op_construct_operand(OP_M64, 0, &(enum registers){REG_RAX}), OP_MODRM_INDIRECT},
-      {op_construct_operand(OP_M64, 8, &(enum registers){REG_RAX}), OP_MODRM_DISP8},
-      {op_construct_operand(OP_M64, 0, &(enum registers){REG_RBP}), OP_MODRM_DISP8},
-      {op_construct_operand(OP_M64, 0xFFFF, &(enum registers){REG_RAX}), OP_MODRM_DISP32},
+      {op_construct_operand(OP_M64, 0, &(enum registers){REG_RIP}, ""), OP_MODRM_INDIRECT},
+      {op_construct_operand(OP_M64, 0, &(enum registers){REG_RAX}, ""), OP_MODRM_INDIRECT},
+      {op_construct_operand(OP_M64, 8, &(enum registers){REG_RAX}, ""), OP_MODRM_DISP8},
+      {op_construct_operand(OP_M64, 0, &(enum registers){REG_RBP}, ""), OP_MODRM_DISP8},
+      {op_construct_operand(OP_M64, 0xFFFF, &(enum registers){REG_RAX}, ""), OP_MODRM_DISP32},
   };
 
   for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {


### PR DESCRIPTION
Since addition and support of the `lable` member of the `operand_t` structure, this funciton, `op_construct_operand` has never supported this member, disallowing the usage and referencing of labels in the assembler.