### PR TITLE
Fixed issue with register not assigning to operand

### DIFF
--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -254,10 +254,8 @@ instruction_t instr_gen(enum instructions instr, uint8_t operand_count, ...) {
         break;
       }
       // clang-format on
-    } else {
-      enum registers temp = va_arg(args, enum registers);
-      data = &temp;
-    }
+    } else
+      data = (void *)&(enum registers){va_arg(args, enum registers)};
 
     const size_t off = va_arg(args, size_t);
     operands[i] = op_construct_operand(type, off, data, label);


### PR DESCRIPTION
For some completely random and obscure reason, when using the `-O3` or whatever optimisation other than the default, the `instruction.c` unit test testing against the `instr_gen` function breaks when called, further digging has revealed for some reason, the `data` value is not being assigned with the required value. (and instead holds a completely insane in place).

This pull has combined the two statements into a compound literal, red- ucing complexity to the code which prevents it from being "optimised" out of the program and therefore breaking whenever a optimisation flag is set in the compiler options.