### PR TITLE
Added pointer for tracking offset changes

### DIFF
--- a/libjas/codegen.c
+++ b/libjas/codegen.c
@@ -108,10 +108,10 @@ buffer_t codegen(enum modes mode, instruction_t *instr_arr, size_t arr_size, enu
    * file offset of the section header table. as we need some space for the data
    * itself for the section.
    */
-  const int base = 6 * 0x40;
+  size_t base = 6 * 0x40;
 
   char shstrtab[] = "\0.shstrtab\0.strtab\0.symtab\0.text\0";
-  buffer_t shstrtab_sect_head = exe_sect_header(1, 0x03, 0, base, sizeof(shstrtab));
+  buffer_t shstrtab_sect_head = exe_sect_header(1, 0x03, 0, &base, sizeof(shstrtab));
 
   buf_write_byte(&strtab, 0);
   buf_write(&symtab, pad, 0x18);
@@ -137,10 +137,9 @@ buffer_t codegen(enum modes mode, instruction_t *instr_arr, size_t arr_size, enu
     free(ent.data);
   }
 
-  buffer_t strtab_sect_head = exe_sect_header(11, 0x03, 0x2, base + sizeof(shstrtab), strtab.len);
-  buffer_t symtab_sect_head = exe_sect_header(19, 0x02, 0x2, base + sizeof(shstrtab) + strtab.len, symtab.len);
-
-  buffer_t text_sect_head = exe_sect_header(27, 0x01, 0x7, base + sizeof(shstrtab) + strtab.len + symtab.len, code.len);
+  buffer_t strtab_sect_head = exe_sect_header(11, 0x03, 0x2, &base, strtab.len);
+  buffer_t symtab_sect_head = exe_sect_header(19, 0x02, 0x2, &base, symtab.len);
+  buffer_t text_sect_head = exe_sect_header(27, 0x01, 0x7, &base, code.len);
 
   // Write and clean everything 🧹🧹
 

--- a/libjas/exe.c
+++ b/libjas/exe.c
@@ -96,7 +96,9 @@ buffer_t exe_header(size_t sect_start, uint16_t sect_count, uint16_t sect_count_
 #define QWORD_PAD \
   &(uint64_t) { 0 }
 
-buffer_t exe_sect_header(uint32_t str_offset, uint32_t type, uint64_t flags, uint64_t off, uint64_t sect_sz) {
+buffer_t exe_sect_header(uint32_t str_offset, uint32_t type, uint64_t flags, uint64_t *off, uint64_t sect_sz) {
+  *off += sect_sz;
+
   buffer_t ret = BUF_NULL;
   buf_write(&ret, (uint8_t *)&str_offset, 4); // String table name offset
   buf_write(&ret, (uint8_t *)&type, 4);       // Section type

--- a/libjas/include/exe.h
+++ b/libjas/include/exe.h
@@ -48,7 +48,7 @@ buffer_t exe_header(size_t sect_start, uint16_t sect_count, uint16_t sect_count_
  * @param str_offset The offset of the string table
  * @param type The type of the section
  * @param flags The flags of the section
- * @param off The offset of the section
+ * @param off The pointer to the offset of the section
  * @param sect_sz The size of the section
  *
  * @return The buffer containing the section header
@@ -57,8 +57,11 @@ buffer_t exe_header(size_t sect_start, uint16_t sect_count, uint16_t sect_count_
  * tree as well as the POSIX ELF standard.
  *
  * @see https://github.com/torvalds/linux/blob/master/include/uapi/linux/elf.h
+ *
+ * @note The `off` pointer is used to keep track of the offset/size of the section
+ * headers and helps the caller to keep track of the section headers.
  */
-buffer_t exe_sect_header(uint32_t str_offset, uint32_t type, uint64_t flags, uint64_t off, uint64_t sect_sz);
+buffer_t exe_sect_header(uint32_t str_offset, uint32_t type, uint64_t flags, uint64_t *off, uint64_t sect_sz);
 
 /**
  * Function for generating a symbol table entry in the ELF object file.


### PR DESCRIPTION
This pull has introduced a pointer argument to the `exe_sect_header` function to allow the function itself to modify the size value *out side* of the function to help the caller (Which in this case is nor- mally the `codegen` function) keep track of the total offset and size of the headers before the sector of the start of the contents of the ELF file. (Where the code, secttion table and everything else goes)