### PR TITLE
Added support for `bswap` instruction

### DIFF
--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -85,6 +85,7 @@ enum instructions {
   INSTR_MOVZX,
   INSTR_MOVSX,
   INSTR_XCHG,
+  INSTR_BSWAP,
 
   INSTR_DUMMY,
 

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -193,6 +193,8 @@ DEFINE_TAB(xchg) = {
     INSTR_TERMINATOR,
 };
 
+DEFINE_TAB(bswap) = {{ENC_O, NULL, {0x0F, 0xC8}, MODE_SUPPORT_ALL, {NULL}, 2, &same_operand_sizes, false}, INSTR_TERMINATOR};
+
 // clang-format off
 
 instr_encode_table_t *instr_table[] =
@@ -200,7 +202,7 @@ instr_encode_table_t *instr_table[] =
         mov, lea, add, sub, mul, div, and, or, xor, _not, inc,
         dec, jmp, je, jne, jz, jnz, call, ret, cmp, push, pop,
         in, out, clc, stc, cli, sti, nop, hlt, _int, syscall, 
-        movzx, movsx, xchg,
+        movzx, movsx, xchg, bswap,
     };
 
 


### PR DESCRIPTION
This pull has added support for the `bswap` instruction in the jas assembler, by adding a new instruction encoder table with the O encoder identitiy, we can easily implement a new instruction as such.