### PR TITLE
Renamed `INSTR_TERMINATOR` to `INSTR_TAB_NULL`

### DIFF
--- a/libjas/codegen.c
+++ b/libjas/codegen.c
@@ -47,7 +47,7 @@ static instr_encode_table_t *get_instr_tabs(instruction_t *instr_arr, size_t arr
 
   for (size_t i = 0; i < arr_size; i++) {
     if (IS_LABEL(instr_arr[i])) {
-      tabs[i] = INSTR_TERMINATOR;
+      tabs[i] = INSTR_TAB_NULL;
       continue;
     }
     tabs[i] = instr_get_tab(instr_arr[i]);

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -121,7 +121,7 @@ typedef struct {
   operand_t *operands;     /* Operands of the instruction */
 } instruction_t;
 
-#define INSTR_TERMINATOR         \
+#define INSTR_TAB_NULL           \
   (instr_encode_table_t) {       \
     .ident = NULL,               \
     .opcode_ext = NULL,          \

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -58,7 +58,7 @@ DEFINE_TAB(mov) = {
     {ENC_OI, NULL, {0xB8}, MODE_SUPPORT_ALL, {0xB0}, 1, &same_operand_sizes},
     {ENC_MI, ZERO_EXT, {0xC7}, MODE_SUPPORT_ALL, {0xC6}, 1, &pre_imm, true},
 
-    INSTR_TERMINATOR,
+    INSTR_TAB_NULL,
 };
 
 static void pre_lea(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
@@ -83,16 +83,16 @@ static void no_operands(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *
       {ENC_MR, NULL, {mr}, MODE_SUPPORT_ALL, {mr_byte}, 1, &same_operand_sizes, true},        \
       {ENC_I, NULL, {i}, MODE_SUPPORT_ALL, {i_byte}, 1, &pre_imm, true},               \
       {ENC_MI, mi_ext, {mi}, MODE_SUPPORT_ALL, {mi_byte}, 1, &pre_imm, true},          \
-      INSTR_TERMINATOR,
+      INSTR_TAB_NULL,
 
 // clang-format on
 
-DEFINE_TAB(lea) = {{ENC_RM, NULL, {0x8D}, MODE_SUPPORT_ALL, {0x8D}, 1, &pre_lea, true}, INSTR_TERMINATOR};
+DEFINE_TAB(lea) = {{ENC_RM, NULL, {0x8D}, MODE_SUPPORT_ALL, {0x8D}, 1, &pre_lea, true}, INSTR_TAB_NULL};
 
 DEFINE_TAB(add) = {GENERIC(0x03, 0x02, 0x01, 0x00, 0x03, 0x02, ZERO_EXT, 0x81, 0x80)};
 DEFINE_TAB(sub) = {GENERIC(0x2B, 0x2A, 0x28, 0x29, 0x2C, 0x2D, 5, 0x81, 0x80)};
-DEFINE_TAB(mul) = {{ENC_M, 4, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes, true}, INSTR_TERMINATOR};
-DEFINE_TAB(div) = {{ENC_M, 6, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes, true}, INSTR_TERMINATOR};
+DEFINE_TAB(mul) = {{ENC_M, 4, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes, true}, INSTR_TAB_NULL};
+DEFINE_TAB(div) = {{ENC_M, 6, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes, true}, INSTR_TAB_NULL};
 
 // Note all or, and and xor instructions have a imm8 which is not supported
 
@@ -102,10 +102,10 @@ DEFINE_TAB(xor) = {GENERIC(0x33, 0x32, 0x31, 0x30, 0x35, 0x34, 6, 0x81, 0x80)};
 
 // ---
 
-DEFINE_TAB(_not) = {{ENC_M, 2, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes, true}, INSTR_TERMINATOR};
+DEFINE_TAB(_not) = {{ENC_M, 2, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operand_sizes, true}, INSTR_TAB_NULL};
 
-DEFINE_TAB(inc) = {{ENC_M, 0, {0xFF}, MODE_SUPPORT_ALL, {0xFE}, 1, &same_operand_sizes, true}, INSTR_TERMINATOR};
-DEFINE_TAB(dec) = {{ENC_M, 1, {0xFF}, MODE_SUPPORT_ALL, {0xFE}, 1, &same_operand_sizes, true}, INSTR_TERMINATOR};
+DEFINE_TAB(inc) = {{ENC_M, 0, {0xFF}, MODE_SUPPORT_ALL, {0xFE}, 1, &same_operand_sizes, true}, INSTR_TAB_NULL};
+DEFINE_TAB(dec) = {{ENC_M, 1, {0xFF}, MODE_SUPPORT_ALL, {0xFE}, 1, &same_operand_sizes, true}, INSTR_TAB_NULL};
 
 static void pre_jcc_no_byte(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
   if (op_sizeof(op_arr[0].type) == 8)
@@ -115,18 +115,18 @@ static void pre_jcc_no_byte(operand_t *op_arr, buffer_t *buf, instr_encode_table
 DEFINE_TAB(jmp) = {
     {ENC_D, NULL, {0xE9}, MODE_SUPPORT_ALL, {0xEB}, 1, NULL, true},
     {ENC_M, 4, {0xFF}, MODE_SUPPORT_ALL, {NULL}, 1, &pre_imm, false},
-    INSTR_TERMINATOR,
+    INSTR_TAB_NULL,
 };
 
-DEFINE_TAB(je) = {{ENC_D, NULL, {0x0f, 0x84}, MODE_SUPPORT_ALL, {0x090, 0x74}, 2, NULL, true}, INSTR_TERMINATOR};
-DEFINE_TAB(jne) = {{ENC_D, NULL, {0x0f, 0x85}, MODE_SUPPORT_ALL, {0x00, 0x00}, 2, &pre_jcc_no_byte, true}, INSTR_TERMINATOR};
-DEFINE_TAB(jz) = {{ENC_D, NULL, {0x0f, 0x84}, MODE_SUPPORT_ALL, {0x00, 0x00}, 2, &pre_jcc_no_byte, true}, INSTR_TERMINATOR};
-DEFINE_TAB(jnz) = {{ENC_D, NULL, {0x0f, 0x85}, MODE_SUPPORT_ALL, {0x90, 0x75}, 2, NULL, true}, INSTR_TERMINATOR};
+DEFINE_TAB(je) = {{ENC_D, NULL, {0x0f, 0x84}, MODE_SUPPORT_ALL, {0x090, 0x74}, 2, NULL, true}, INSTR_TAB_NULL};
+DEFINE_TAB(jne) = {{ENC_D, NULL, {0x0f, 0x85}, MODE_SUPPORT_ALL, {0x00, 0x00}, 2, &pre_jcc_no_byte, true}, INSTR_TAB_NULL};
+DEFINE_TAB(jz) = {{ENC_D, NULL, {0x0f, 0x84}, MODE_SUPPORT_ALL, {0x00, 0x00}, 2, &pre_jcc_no_byte, true}, INSTR_TAB_NULL};
+DEFINE_TAB(jnz) = {{ENC_D, NULL, {0x0f, 0x85}, MODE_SUPPORT_ALL, {0x90, 0x75}, 2, NULL, true}, INSTR_TAB_NULL};
 
 DEFINE_TAB(call) = {
     {ENC_D, NULL, {0xE8}, MODE_SUPPORT_ALL, {0xEB}, 1, NULL, true},
     {ENC_M, 2, {0xFF}, MODE_SUPPORT_ALL, {NULL}, 1, &pre_imm, false},
-    INSTR_TERMINATOR,
+    INSTR_TAB_NULL,
 };
 
 static void pre_ret(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
@@ -138,7 +138,7 @@ static void pre_ret(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *inst
 DEFINE_TAB(ret) = {
     {ENC_ZO, NULL, {0xC3}, MODE_SUPPORT_ALL, {0xC3}, 1, &no_operands, true},
     {ENC_I, NULL, {0xC2}, MODE_SUPPORT_ALL, {0xC2}, 1, &pre_ret, true},
-    INSTR_TERMINATOR,
+    INSTR_TAB_NULL,
 };
 
 DEFINE_TAB(cmp) = {GENERIC(0x3B, 0x3A, 0x39, 0x38, 0x3D, 0x3C, 7, 0x81, 0x80)};
@@ -147,35 +147,35 @@ DEFINE_TAB(push) = {
     {ENC_M, 6, {0xFF}, MODE_SUPPORT_ALL, NULL, 1, NULL, false},
     {ENC_O, NULL, {0x50}, MODE_SUPPORT_ALL, NULL, 1, NULL, false},
     {ENC_I, NULL, {0x68}, MODE_SUPPORT_ALL, {0x6A}, 1, &pre_imm, true},
-    INSTR_TERMINATOR,
+    INSTR_TAB_NULL,
 };
 
 DEFINE_TAB(pop) = {
     {ENC_M, 0, {0x8F}, MODE_SUPPORT_ALL, NULL, 1, NULL, false},
     {ENC_O, NULL, {0x58}, MODE_SUPPORT_ALL, NULL, 1, NULL, false},
-    INSTR_TERMINATOR,
+    INSTR_TAB_NULL,
 };
 
 DEFINE_TAB(in) = {{}};
 DEFINE_TAB(out) = {{}};
 
-DEFINE_TAB(clc) = {{ENC_ZO, NULL, {0xF8}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TERMINATOR};
-DEFINE_TAB(stc) = {{ENC_ZO, NULL, {0xF9}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TERMINATOR};
-DEFINE_TAB(cli) = {{ENC_ZO, NULL, {0xFA}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TERMINATOR};
-DEFINE_TAB(sti) = {{ENC_ZO, NULL, {0xFB}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TERMINATOR};
+DEFINE_TAB(clc) = {{ENC_ZO, NULL, {0xF8}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL};
+DEFINE_TAB(stc) = {{ENC_ZO, NULL, {0xF9}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL};
+DEFINE_TAB(cli) = {{ENC_ZO, NULL, {0xFA}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL};
+DEFINE_TAB(sti) = {{ENC_ZO, NULL, {0xFB}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL};
 
-DEFINE_TAB(nop) = {{ENC_ZO, NULL, {0x90}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TERMINATOR};
-DEFINE_TAB(hlt) = {{ENC_ZO, NULL, {0xF4}, MODE_SUPPORT_ALL, {0xF4}, 1, &no_operands, true}, INSTR_TERMINATOR};
+DEFINE_TAB(nop) = {{ENC_ZO, NULL, {0x90}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL};
+DEFINE_TAB(hlt) = {{ENC_ZO, NULL, {0xF4}, MODE_SUPPORT_ALL, {0xF4}, 1, &no_operands, true}, INSTR_TAB_NULL};
 
 static void pre_int(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
   if (op_sizeof(op_arr[0].type) != 8)
     err("Invalid operand size for INT instruction.");
 }
 
-DEFINE_TAB(_int) = {{ENC_I, NULL, {0xCD}, MODE_SUPPORT_ALL, {NULL}, 1, &pre_int, false}, INSTR_TERMINATOR};
+DEFINE_TAB(_int) = {{ENC_I, NULL, {0xCD}, MODE_SUPPORT_ALL, {NULL}, 1, &pre_int, false}, INSTR_TAB_NULL};
 DEFINE_TAB(syscall) = {
     {ENC_ZO, NULL, {0x0F, 0x05}, MODE_SUPPORT_64BIT, {NULL}, 2, &same_operand_sizes, false},
-    INSTR_TERMINATOR,
+    INSTR_TAB_NULL,
 };
 
 static void pre_small_operands(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
@@ -183,14 +183,14 @@ static void pre_small_operands(operand_t *op_arr, buffer_t *buf, instr_encode_ta
     err("Invalid operand size for MOVZX/MOVSX instruction");
 }
 
-DEFINE_TAB(movzx) = {{ENC_RM, NULL, {0x0F, 0xB7}, MODE_SUPPORT_ALL, {0x0F, 0xB6}, 2, &pre_small_operands, true}, INSTR_TERMINATOR};
-DEFINE_TAB(movsx) = {{ENC_RM, NULL, {0x0F, 0xBF}, MODE_SUPPORT_ALL, {0x0F, 0xBE}, 2, &pre_small_operands, true}, INSTR_TERMINATOR};
+DEFINE_TAB(movzx) = {{ENC_RM, NULL, {0x0F, 0xB7}, MODE_SUPPORT_ALL, {0x0F, 0xB6}, 2, &pre_small_operands, true}, INSTR_TAB_NULL};
+DEFINE_TAB(movsx) = {{ENC_RM, NULL, {0x0F, 0xBF}, MODE_SUPPORT_ALL, {0x0F, 0xBE}, 2, &pre_small_operands, true}, INSTR_TAB_NULL};
 
 DEFINE_TAB(xchg) = {
     {ENC_O, NULL, {0x90}, MODE_SUPPORT_ALL, {NULL}, 1, &same_operand_sizes, false},
     {ENC_MR, NULL, {0x87}, MODE_SUPPORT_ALL, {0x86}, 1, &same_operand_sizes, true},
     {ENC_RM, NULL, {0x87}, MODE_SUPPORT_ALL, {0x86}, 1, &same_operand_sizes, true},
-    INSTR_TERMINATOR,
+    INSTR_TAB_NULL,
 };
 
 // clang-format off
@@ -207,8 +207,8 @@ instr_encode_table_t *instr_table[] =
 #define CURR_TABLE instr_table[instr.instr][j]
 
 instr_encode_table_t instr_get_tab(instruction_t instr) {
-  if (instr.instr == NULL && instr.operands == NULL) return INSTR_TERMINATOR;
-  if (IS_LABEL(instr)) return INSTR_TERMINATOR; // aka empty
+  if (instr.instr == NULL && instr.operands == NULL) return INSTR_TAB_NULL;
+  if (IS_LABEL(instr)) return INSTR_TAB_NULL; // aka empty
   const enum operands operand_list[4] = {
       instr.operands[0].type, instr.operands[1].type,
       instr.operands[2].type, instr.operands[3].type,
@@ -227,7 +227,7 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
 
   // fall-through; no corresponding instruction opcode found
   err("No corrsponding instruction opcode found.");
-  return INSTR_TERMINATOR; // aka empty
+  return INSTR_TAB_NULL; // aka empty
 }
 
 instruction_t instr_gen(enum instructions instr, uint8_t operand_count, ...) {


### PR DESCRIPTION
This commit has changed the name of the previous terminator to a "null wrapper" for a more "practical" name. For example, the `instr_ get_tab` function uses the `INSTR_TERMINATOR` as a default empty value, which does not fall under the "termination" category and does not need to be listed as that.