### PR TITLE
Refactor and isolate pre processors

### DIFF
--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -25,10 +25,11 @@
 
 #include "instruction.h"
 #include "error.h"
-#include "pre.c"
 #include "register.h"
 #include <stdarg.h>
 #include <stddef.h>
+
+#include "pre.c"
 
 #define ZERO_EXT 0b10000000
 #define DEFINE_TAB(name) instr_encode_table_t name[]

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -25,29 +25,10 @@
 
 #include "instruction.h"
 #include "error.h"
+#include "pre.c"
 #include "register.h"
 #include <stdarg.h>
 #include <stddef.h>
-
-static void same_operand_sizes(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
-  const uint8_t ref = op_sizeof(op_arr[0].type);
-
-  for (uint8_t i = 0; i < 4; i++) {
-    if (op_arr[i].type == OP_NULL) continue;
-
-    if (op_sizeof(op_arr[i].type) != ref) {
-      err("Invalid operand sizes.");
-      break;
-    }
-  }
-}
-
-static void pre_imm(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
-  if (op_sizeof(op_arr[0].type) != 64) {
-    same_operand_sizes(op_arr, buf, instr_ref, mode);
-    return;
-  }
-}
 
 #define ZERO_EXT 0b10000000
 #define DEFINE_TAB(name) instr_encode_table_t name[]
@@ -60,21 +41,6 @@ DEFINE_TAB(mov) = {
 
     INSTR_TERMINATOR,
 };
-
-static void pre_lea(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
-  if (op_m(op_arr[0].type) || op_r(op_arr[1].type))
-    err("Invalid operands type for LEA instruction.");
-
-  if (op_sizeof(op_arr[0].type) == 8)
-    err("Byte operands cannot be used with the LEA instruction.");
-}
-
-static void no_operands(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
-  for (uint8_t i = 0; i < 4; i++) {
-    if (op_arr[i].type != OP_NULL)
-      err("This encoder identity does not support any operands.");
-  }
-}
 
 // clang-format off
 
@@ -107,11 +73,6 @@ DEFINE_TAB(_not) = {{ENC_M, 2, {0xF7}, MODE_SUPPORT_ALL, {0xF6}, 1, &same_operan
 DEFINE_TAB(inc) = {{ENC_M, 0, {0xFF}, MODE_SUPPORT_ALL, {0xFE}, 1, &same_operand_sizes, true}, INSTR_TERMINATOR};
 DEFINE_TAB(dec) = {{ENC_M, 1, {0xFF}, MODE_SUPPORT_ALL, {0xFE}, 1, &same_operand_sizes, true}, INSTR_TERMINATOR};
 
-static void pre_jcc_no_byte(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
-  if (op_sizeof(op_arr[0].type) == 8)
-    err("Byte operands cannot be used with this instruction.");
-}
-
 DEFINE_TAB(jmp) = {
     {ENC_D, NULL, {0xE9}, MODE_SUPPORT_ALL, {0xEB}, 1, NULL, true},
     {ENC_M, 4, {0xFF}, MODE_SUPPORT_ALL, {NULL}, 1, &pre_imm, false},
@@ -128,11 +89,6 @@ DEFINE_TAB(call) = {
     {ENC_M, 2, {0xFF}, MODE_SUPPORT_ALL, {NULL}, 1, &pre_imm, false},
     INSTR_TERMINATOR,
 };
-
-static void pre_ret(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
-  if (op_sizeof(op_arr[0].type) != 16)
-    err("Other operand sizes cannot be used with this instruction.");
-}
 
 // TODO / note far jumps, calls and returns are not supported (yet)
 DEFINE_TAB(ret) = {
@@ -167,21 +123,11 @@ DEFINE_TAB(sti) = {{ENC_ZO, NULL, {0xFB}, MODE_SUPPORT_ALL, {NULL}, 1, &no_opera
 DEFINE_TAB(nop) = {{ENC_ZO, NULL, {0x90}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TERMINATOR};
 DEFINE_TAB(hlt) = {{ENC_ZO, NULL, {0xF4}, MODE_SUPPORT_ALL, {0xF4}, 1, &no_operands, true}, INSTR_TERMINATOR};
 
-static void pre_int(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
-  if (op_sizeof(op_arr[0].type) != 8)
-    err("Invalid operand size for INT instruction.");
-}
-
 DEFINE_TAB(_int) = {{ENC_I, NULL, {0xCD}, MODE_SUPPORT_ALL, {NULL}, 1, &pre_int, false}, INSTR_TERMINATOR};
 DEFINE_TAB(syscall) = {
     {ENC_ZO, NULL, {0x0F, 0x05}, MODE_SUPPORT_64BIT, {NULL}, 2, &same_operand_sizes, false},
     INSTR_TERMINATOR,
 };
-
-static void pre_small_operands(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
-  if (op_sizeof(op_arr[1].type) < 16)
-    err("Invalid operand size for MOVZX/MOVSX instruction");
-}
 
 DEFINE_TAB(movzx) = {{ENC_RM, NULL, {0x0F, 0xB7}, MODE_SUPPORT_ALL, {0x0F, 0xB6}, 2, &pre_small_operands, true}, INSTR_TERMINATOR};
 DEFINE_TAB(movsx) = {{ENC_RM, NULL, {0x0F, 0xBF}, MODE_SUPPORT_ALL, {0x0F, 0xBE}, 2, &pre_small_operands, true}, INSTR_TERMINATOR};

--- a/libjas/pre.c
+++ b/libjas/pre.c
@@ -1,0 +1,57 @@
+#include "error.h"
+#include "operand.h"
+
+static void pre_lea(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+  if (op_m(op_arr[0].type) || op_r(op_arr[1].type))
+    err("Invalid operands type for LEA instruction.");
+
+  if (op_sizeof(op_arr[0].type) == 8)
+    err("Byte operands cannot be used with the LEA instruction.");
+}
+
+static void no_operands(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+  for (uint8_t i = 0; i < 4; i++) {
+    if (op_arr[i].type != OP_NULL)
+      err("This encoder identity does not support any operands.");
+  }
+}
+
+static void same_operand_sizes(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+  const uint8_t ref = op_sizeof(op_arr[0].type);
+
+  for (uint8_t i = 0; i < 4; i++) {
+    if (op_arr[i].type == OP_NULL) continue;
+
+    if (op_sizeof(op_arr[i].type) != ref) {
+      err("Invalid operand sizes.");
+      break;
+    }
+  }
+}
+
+static void pre_imm(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+  if (op_sizeof(op_arr[0].type) != 64) {
+    same_operand_sizes(op_arr, buf, instr_ref, mode);
+    return;
+  }
+}
+
+static void pre_jcc_no_byte(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+  if (op_sizeof(op_arr[0].type) == 8)
+    err("Byte operands cannot be used with this instruction.");
+}
+
+static void pre_ret(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+  if (op_sizeof(op_arr[0].type) != 16)
+    err("Other operand sizes cannot be used with this instruction.");
+}
+
+static void pre_int(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+  if (op_sizeof(op_arr[0].type) != 8)
+    err("Invalid operand size for INT instruction.");
+}
+
+static void pre_small_operands(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+  if (op_sizeof(op_arr[1].type) < 16)
+    err("Invalid operand size for MOVZX/MOVSX instruction");
+}

--- a/libjas/pre.c
+++ b/libjas/pre.c
@@ -1,7 +1,10 @@
 #include "error.h"
 #include "operand.h"
 
-static void pre_lea(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+#define DEFINE_PRE_ENCODER(name) \
+  static void name(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode)
+
+DEFINE_PRE_ENCODER(pre_lea) {
   if (op_m(op_arr[0].type) || op_r(op_arr[1].type))
     err("Invalid operands type for LEA instruction.");
 
@@ -9,14 +12,14 @@ static void pre_lea(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *inst
     err("Byte operands cannot be used with the LEA instruction.");
 }
 
-static void no_operands(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+DEFINE_PRE_ENCODER(no_operands) {
   for (uint8_t i = 0; i < 4; i++) {
     if (op_arr[i].type != OP_NULL)
       err("This encoder identity does not support any operands.");
   }
 }
 
-static void same_operand_sizes(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+DEFINE_PRE_ENCODER(same_operand_sizes) {
   const uint8_t ref = op_sizeof(op_arr[0].type);
 
   for (uint8_t i = 0; i < 4; i++) {
@@ -29,29 +32,29 @@ static void same_operand_sizes(operand_t *op_arr, buffer_t *buf, instr_encode_ta
   }
 }
 
-static void pre_imm(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+DEFINE_PRE_ENCODER(pre_imm) {
   if (op_sizeof(op_arr[0].type) != 64) {
     same_operand_sizes(op_arr, buf, instr_ref, mode);
     return;
   }
 }
 
-static void pre_jcc_no_byte(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+DEFINE_PRE_ENCODER(pre_jcc_no_byte) {
   if (op_sizeof(op_arr[0].type) == 8)
     err("Byte operands cannot be used with this instruction.");
 }
 
-static void pre_ret(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+DEFINE_PRE_ENCODER(pre_ret) {
   if (op_sizeof(op_arr[0].type) != 16)
     err("Other operand sizes cannot be used with this instruction.");
 }
 
-static void pre_int(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+DEFINE_PRE_ENCODER(pre_int) {
   if (op_sizeof(op_arr[0].type) != 8)
     err("Invalid operand size for INT instruction.");
 }
 
-static void pre_small_operands(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
+DEFINE_PRE_ENCODER(pre_small_operands) {
   if (op_sizeof(op_arr[1].type) < 16)
     err("Invalid operand size for MOVZX/MOVSX instruction");
 }


### PR DESCRIPTION
This pull has moved over all the pre processor functions from
the `instruction.c` file. Since the `instruction.c` file is already
fairly crowded from all the instruction encoder tables (With more
coming soon), there was no reason for the pre-processor functions
to be crowding around with no direct benefits to the tables *itself*
    
Therefore, these pre-processors has been ported over to a new file
and included *directly* (Which I know is relatively bad practice)