### PR TITLE
Fixed incorrect offset values.

### DIFF
--- a/libjas/exe.c
+++ b/libjas/exe.c
@@ -97,8 +97,6 @@ buffer_t exe_header(size_t sect_start, uint16_t sect_count, uint16_t sect_count_
   &(uint64_t) { 0 }
 
 buffer_t exe_sect_header(uint32_t str_offset, uint32_t type, uint64_t flags, uint64_t *off, uint64_t sect_sz) {
-  *off += sect_sz;
-
   buffer_t ret = BUF_NULL;
   buf_write(&ret, (uint8_t *)&str_offset, 4); // String table name offset
   buf_write(&ret, (uint8_t *)&type, 4);       // Section type
@@ -106,8 +104,9 @@ buffer_t exe_sect_header(uint32_t str_offset, uint32_t type, uint64_t flags, uin
 
   buf_write(&ret, QWORD_PAD, 8); // Section address
 
-  buf_write(&ret, (uint8_t *)&off, 8);     // Section file offset
+  buf_write(&ret, (uint8_t *)off, 8);      // Section file offset
   buf_write(&ret, (uint8_t *)&sect_sz, 8); // Section size
+  *off += sect_sz;
 
   int int_pad = 0;
 


### PR DESCRIPTION
After the switch to updating the ELF offset using pointers to allow the offset value to be updated automatically within the function. Some other functionality has broke since the changes in #39 and as outlined above. First of all, the outstanding issue causing issues after the change is the "pre mature" modification of the offset before it was used.

In particular, the modification line:
  > *off += sect_sz;

Was placed **before** the line where *it was used*:
  > buf_write(&ret, (uint8_t *)off, 8);

This means, the value is incorrectly referenced, however, this is not the primary issue *(I think)*. The primary issue I think is the fact that I am referencing the pointer to the `off` pointer.

Previously, the offset was written as `&off` which is the **address** of `off`, instead of the value.