### PR TITLE
Removed usage of `is_pre` globally (See below)

### DIFF
--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -52,8 +52,7 @@ static void ref_label(operand_t *op_arr, buffer_t *buf, uint8_t index) {
     return;
   }
 
-  extern bool is_pre;
-  int32_t rel_offset = is_pre ? 0 : label->address - (buf->len + rel_sz - 1) - 1;
+  int32_t rel_offset = label->address == 0 ? 0 : label->address - (buf->len + rel_sz - 1) - 1;
   buf_write(buf, (uint8_t *)&rel_offset, rel_sz);
 }
 
@@ -114,7 +113,7 @@ DEFINE_ENCODER(m) {
 }
 
 /**
- * @note - Internal documentation (31th Dec 2024 - Last day of '24 🎉) 
+ * @note - Internal documentation (31th Dec 2024 - Last day of '24 🎉)
  * This function will be used to write a number (aka a immediate value)
  * to the buffer, which is considered a common ground for many encoder
  * identities, such as `mi`, `oi` etc that also require a immediate value


### PR DESCRIPTION
This pull has removed the usage and definiton of the `is_pre` global variable that was used to define the state of the assembler (As the name suggests, if the assembler was in the pre-processor state for resolving labels, or in the primary assembling mode.)

To reduce naming clashes, reliance on external variables that can be reliant on unreliable external sources, these variables are better off removing them. (a. I'm going to forget them, or b. I'll be very confused managing them) Besides, it's never good for a function to rely on anything other than its parameters.

Believe it or not, the global variable in the `codegen.c` file and the `encoder.c` file was **completely not required**, there was absolutely *no reason* for the global variable to *exist*.

Since the global variable was used to depict wether we needed to set the `rel_offset` as 0, there was actually *no value* in setting it as `0`, even though if it was garbage, there would be no change in the size (Which is the only thing we wanted to get out of the pre- prcessor, at this stage)

---

Besides removing the reliance of global variables, the `assemble` function has also received sanity checks to prevent duplicate and not needed loops and iterations over certain arrays and lists, and also when there are lables to resolve where we can skip it *altogether*.