### PR TITLE
Added macros for working with `instr_gen()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,26 +15,15 @@
 <p align="center" padding="10px"> Jas is a minimal, fast and simple zero-dependency assembler for the x64 family of processors, jas not only aims to be fast and simple when using it but also aims to be a learning reasource for others to learn about low-level system programming and the x64 instruction set. Useful for implementing into compilers, operating systems and JIT interpreters and other types of utilites that need compilation to ELF or just a plain enocded buffer. </p>
 
 ### ⚡Quick start
-First of all, install/link against the binary releases [here](https://github.com/cheng-alvin/jas/releases) or build it from source with following the instructions below. Jas takes instructions in an array in a struct form defined in [instruction.h](https://github.com/cheng-alvin/jas/blob/0faa905be7cb1238796af46552b3271a11b4e2dd/libjas/instruction.h) and passes it to a `codegen()` function which generates the the actual buffer of an array of `uint8_t` for you to process.
+First of all, install/link against the binary releases [here](https://github.com/cheng-alvin/jas/releases) or build it from source with following the instructions below. Jas takes instructions in an array in a struct form defined in [instruction.h](https://github.com/cheng-alvin/jas/blob/0faa905be7cb1238796af46552b3271a11b4e2dd/libjas/instruction.h) and passes it to a `assemble_instr()` function which generates the the actual buffer of an array of `uint8_t` for you to process. (However, in this situation, we are using the `instr_gen()` function and operand generation macros to generate the instruction structure automatically without the janky C structure syntax)
 ```c
 #include <jas.h>
 #include <stdint.h>
 #include <stdlib.h>
 
 int main(void) {
-  instruction_t instr[] = {
-      (instruction_t){
-          .instr = INSTR_MOV,
-          .operands = (operand_t[]){
-              (operand_t){.type = OP_R64, .data = &(enum registers){REG_RAX}},
-              (operand_t){.type = OP_IMM64, .data = &(uint64_t){0}},
-              OP_NONE,
-              OP_NONE,
-          },
-      },
-  };
-
-  buffer_t buf = codegen(MODE_LONG, instr, sizeof(instr), CODEGEN_RAW);
+  instruction_t instr = instr_gen(INSTR_MOV, 2, r64(REG_RAX), imm64(0));
+  buffer_t buf = assemble_instr(MODE_LONG, instr, CODEGEN_RAW);
 
   /* Do something to `buf.data` - The uint8_t array */
 

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -156,6 +156,63 @@ typedef struct {
 instr_encode_table_t instr_get_tab(instruction_t instr);
 
 /**
+ * Macros for defining the instruction operands in a more readable
+ * form for passing into the `instr_gen` function. The macros are
+ * used to define the operand type, register, immediate, memory
+ * and relative operands.
+ *
+ * @example
+ * We dont need to type in: `instr_gen(INSTR_MOV, 1, OP_R64, REG_RAX, 0);`
+ * But instead, we can type in: `instr_gen(INSTR_MOV, 1, r64(REG_RAX));`
+ */
+
+#define r64(x) OP_R64, x, 0
+#define r32(x) OP_R32, x, 0
+#define r16(x) OP_R16, x, 0
+
+#define imm8(x) OP_IMM8, x, 0
+#define imm16(x) OP_IMM16, x, 0
+#define imm32(x) OP_IMM32, x, 0
+#define imm64(x) OP_IMM64, x, 0
+
+// --
+
+/**
+ * These Relative macros are used to define the relative operand,
+ * usually using labels. The relative operand is used in jump
+ * instructions and other instructions that require a relative
+ * offset to a label.
+ *
+ * @example rel("label", 10)
+ */
+
+#define rel8(x, off) OP_REL8, x, off
+#define rel32(x, off) OP_REL32, x, off
+
+// Note: offset must be provided - equivalent to: [eax + xyz]
+// (SIB bytes and another register for displacement not supported)
+
+#define m8(x, off) OP_M8, x, off
+#define m16(x, off) OP_M16, x, off
+#define m32(x, off) OP_M32, x, off
+#define m64(x, off) OP_M64, x, off
+
+/**
+ * Not to be confused with the `r8` and other operand macros, this
+ * macro is used to define the accumulator register operand in the
+ * instruction. Like rax, eax etc. This wouldn't work when used with
+ * instructions that dont support the accumulator register.
+ *
+ * Check the Intel manual, whatever the intel manual says is as a valid
+ * accumulator is the default implemented version.
+ */
+
+#define acc8 OP_ACC8, REG_AL, 0
+#define acc16 OP_ACC16, REG_AX, 0
+#define acc32 OP_ACC32, REG_EAX, 0
+#define acc64 OP_ACC64, REG_RAX, 0
+
+/**
  * A function for easily defining a instruction in the `instruction_t`
  * form without having to use the struct initializer or mangle around
  * with void pointers and curly braces. This function is used to create
@@ -167,27 +224,6 @@ instr_encode_table_t instr_get_tab(instruction_t instr);
  * @param ... The operands to pass (Refer to below example)
  *
  * @return The instruction struct
- *
- * @note All operands will be grouped into three arguments, a type, offset
- * and data, similar to the ones of the `operand_t` struct.
- *
- * @example instr_gen(INSTR_XXX, 1, OP_R64, REG_RAX, 0);
- *
- * The example above will generate a instruction struct with the
- * instruction type `INSTR_XXX` and a single operand with the type
- * `OP_R64`, an offset of `0` and the data `REG_RAX`, which returns:
- *
- * ```
- * (instruction_t){
- *   .instr = INSTR_XXX,
- *   .operands = (operand_t[]){
- *     (operand_t)
- *     {.type = OP_R64, .offset = 0, .data = &(enum registers){REG_RAX}},
- *     OP_NONE, OP_NONE, OP_NONE,
- *   },
- * }
- *```
- *
  * @see `operand_t`
  */
 instruction_t instr_gen(enum instructions instr, uint8_t operand_count, ...);

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -169,13 +169,14 @@ instr_encode_table_t instr_get_tab(instruction_t instr);
 #define r64(x) OP_R64, x, 0
 #define r32(x) OP_R32, x, 0
 #define r16(x) OP_R16, x, 0
+#define r8(x) OP_R8, x, 0
+
+// --
 
 #define imm8(x) OP_IMM8, x, 0
 #define imm16(x) OP_IMM16, x, 0
 #define imm32(x) OP_IMM32, x, 0
 #define imm64(x) OP_IMM64, x, 0
-
-// --
 
 /**
  * These Relative macros are used to define the relative operand,

--- a/tests/instruction.c
+++ b/tests/instruction.c
@@ -2,7 +2,7 @@
 #include "test.h"
 
 Test(instr, instr_gen) {
-  instruction_t instr = instr_gen(INSTR_MOV, 2, OP_R64, REG_RAX, 0, OP_IMM64, 0x0, 0);
+  instruction_t instr = instr_gen(INSTR_MOV, 2, r64(REG_RAX), imm64(0));
   assert_eq(instr.instr, INSTR_MOV);
 
   assert_eq(instr.operands[0].type, OP_R64);
@@ -16,12 +16,12 @@ Test(instr, instr_gen) {
   assert_eq(instr.operands[2].type, OP_NULL);
   assert_eq(instr.operands[3].type, OP_NULL);
 
-  instr = instr_gen(INSTR_MOV, 2, OP_R64, REG_RAX, 0, OP_REL32, "label", 0);
+  instr = instr_gen(INSTR_MOV, 2, r32(REG_EAX), rel32("label", 0));
 
   assert_eq(instr.instr, INSTR_MOV);
 
-  assert_eq(instr.operands[0].type, OP_R64);
-  assert_eq(*(enum registers *)instr.operands[0].data, REG_RAX);
+  assert_eq(instr.operands[0].type, OP_R32);
+  assert_eq(*(enum registers *)instr.operands[0].data, REG_EAX);
   assert_eq(instr.operands[0].offset, 0);
 
   assert_eq(instr.operands[1].type, OP_REL32);


### PR DESCRIPTION
This pull has added operand generation "helper" macros for the `instr_gen()` function, allowing callers to write simpler and less confusing functions with less boiler-plate code

Previously, to write a `mov rax, 0` instruction you had to call:
> `instr_gen(INSTR_MOV, 2, OP_R64, REG_RAX, 0, OP_IMM64, 0, 0);`

Now, the caller can use the macro to *automatically fill* the operands like so:
> `instr_gen(INSTR_MOV, 2, r64(REG_RAX), imm64(0));`

Theres less clutter, and we can easily read it without manually counting arguments.