### PR TITLE
Added `label_gen()` funciton

### DIFF
--- a/libjas/include/label.h
+++ b/libjas/include/label.h
@@ -26,6 +26,7 @@
 #ifndef LABEL_H
 #define LABEL_H
 
+#include "instruction.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -90,4 +91,35 @@ void label_destroy_all();
  */
 label_t *label_lookup(char *name);
 
+/**
+ * Enumeration for expressing the different types of labels used
+ * in the assembler, such as local, global, and external labels.
+ *
+ * Determines the type of label to be created in the assembler.
+ * (And if a label table should be generated)
+ */
+
+enum label_type {
+  LABEL_LOCAL,
+  LABEL_GLOBAL,
+  LABEL_EXTERN,
+};
+
+/**
+ * Function similar to `instr_ge()` and `label_create()`, used to
+ * generate a label instruction in the instruction array, and
+ * return the instruction struct back to the caller.
+ *
+ * @param name The name of the label to be generated.
+ * @param type The type of the label. @see `enum label_type`
+ *
+ * @return The instruction struct of the label generated.
+ *
+ * @note The label name should not contain the `:` character, as
+ * it is automatically added by the assembler. (The `:` character
+ * is a label terminator usually found in assembly languages, and
+ * does not get used in this assembler, typing in `:` would result
+ * in that carrying over to the output)
+ */
+instruction_t label_gen(char *name, enum label_type type);
 #endif

--- a/libjas/label.c
+++ b/libjas/label.c
@@ -69,3 +69,24 @@ label_t *label_lookup(char *name) {
 
 size_t label_get_size() { return label_table_size; }
 label_t *label_get_table() { return label_table; }
+
+instruction_t label_gen(char *name, enum label_type type) {
+  enum instructions instr = INSTR_DIR_LOCAL_LABEL;
+
+  // clang-format off
+  switch (type) {
+    case LABEL_LOCAL: instr = INSTR_DIR_LOCAL_LABEL; break;
+    case LABEL_GLOBAL: instr = INSTR_DIR_GLOBAL_LABEL; break;
+    case LABEL_EXTERN: instr = INSTR_DIR_EXTERN_LABEL; break;
+
+    default: break;
+  }
+  // clang-format on
+
+  return (instruction_t){
+      .instr = instr,
+      .operands = (operand_t[]){
+          op_construct_operand(OP_MISC, 0, name, NULL),
+      },
+  };
+}


### PR DESCRIPTION
This pull has added the `label_gen()` funciton, this function is a similar `instr_gen` *corrisponding counterpart* to the `instr_gen` function, but as the name suggests, for generating labels. This funciton takes in a label `name` and `type` as arguments (as documented).