### PR TITLE
Fix instr gen

### DIFF
--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -69,6 +69,13 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
   return INSTR_TAB_NULL; // aka empty
 }
 
+#define alloc_operand_data(type)          \
+  do {                                    \
+    type *type##_ = malloc(sizeof(type)); \
+    *type##_ = va_arg(args, type);        \
+    data = (void *)type##_;               \
+  } while (0);
+
 /* Stupid almost-stub implementation */
 instruction_t instr_gen(enum instructions instr, uint8_t operand_count, ...) {
   va_list args;
@@ -92,11 +99,6 @@ instruction_t instr_gen(enum instructions instr, uint8_t operand_count, ...) {
       label = strdup(lab);
 
       // clang-format off
-    #define alloc_operand_data(type)        \
-      type *type##_ = malloc(sizeof(type)); \
-      *type##_ = va_arg(args, type);        \
-      data = (void *)type##_;
-
     } else if (op_imm(type)) {
       switch (op_sizeof(type)) {
       case 8: alloc_operand_data(uint8_t); break;


### PR DESCRIPTION
Fixed `instr_gen` function
    
After some days of debugging later, (well, it was very very confusing)
the root issue for the incorrect instruction was finally found.
    
Since all local variables in C included within a funciton is stored on
the stack frame, it will get cleaned-up after the function exits/returns,
therefore, when `instruction_t` struct was returned from the `instr_gen`
function, we were reading from the *stack frame* instead of *actual
memory*. After other functions were called, the stack frame where the
previous `instruction_t` struct was stored was overwitten ang and placed
back in with some random garbage.
    
This pull is a *almost stub* implementation/fix for the `instr_gen` function,
in particular, it allows memory to be allocated dynamically to support the
storage of these titems that were temporary when implemented on the stack
frame.
    
---
    
**Unrelated:** This commit has also modified the names of the `div` instruction
enocder table as per the changes explained in #49.
