### PR TITLE
Removed `-Ofast` flag in favor of `-O3`

### DIFF
--- a/libjas/Makefile
+++ b/libjas/Makefile
@@ -1,6 +1,6 @@
 CC = clang
 
-CFLAGS_COMMON =-I include -Wno-incompatible-pointer-types -Wno-int-conversion -Ofast
+CFLAGS_COMMON =-I include -Wno-incompatible-pointer-types -Wno-int-conversion -O3
 CFLAGS = $(CFLAGS_COMMON)
 
 C_SRC = $(wildcard *.c) # Includes only C source files


### PR DESCRIPTION
Since the removal and deprecated optimisation flag `-Ofast` providing un-supported and non-standard optimisations for speed was removed in subsequent versions of clang, this pull has removed this flag in favor for the next best optimisation of `-O3`