### PR TITLE
Added dynamic memory allocations to generators

### DIFF
--- a/libjas/include/jas.h
+++ b/libjas/include/jas.h
@@ -51,6 +51,7 @@ namespace jas {
 #include "codegen.h"
 #include "error.h"
 #include "instruction.h"
+#include "label.h"
 #include "mode.h"
 #include "operand.h"
 #include "register.h"

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -139,8 +139,11 @@ instruction_t instr_write_bytes(size_t data_sz, ...) {
     buf_write_byte(&data, byte);
   }
 
+  va_end(args);
+
+  instruction_t *instr_ret = malloc(sizeof(instruction_t));
   // clang-format off
-  return (instruction_t){
+  *instr_ret = (instruction_t){
       .instr = INSTR_DIR_WRT_BUF,
       .operands = (operand_t[]){
           op_construct_operand(OP_MISC, 0, &data, NULL),
@@ -148,4 +151,5 @@ instruction_t instr_write_bytes(size_t data_sz, ...) {
       },
   };
   // clang-format on
+  return *instr_ret;
 }

--- a/libjas/label.c
+++ b/libjas/label.c
@@ -82,10 +82,14 @@ instruction_t label_gen(char *name, enum label_type type) {
   }
   // clang-format on
 
-  return (instruction_t){
+  name = strdup(name);
+  instruction_t *instr_ret = malloc(sizeof(instruction_t));
+  *instr_ret = (instruction_t){
       .instr = instr,
       .operands = (operand_t[]){
           op_construct_operand(OP_MISC, 0, name, NULL),
       },
   };
+
+  return *instr_ret;
 }


### PR DESCRIPTION
After the fix in #50, which only covered the `instr_gen` function, this pull has taken a similar method in patching the other generation function for generating a `instruction_t` struct dynamically.

Please see #50