### PR TITLE
Removed -Og compiler flags

### DIFF
--- a/libjas/Makefile
+++ b/libjas/Makefile
@@ -10,11 +10,11 @@ BUILD = ../build
 libjas.a: $(OBJ) 
 	ar rcs $(BUILD)/$@ $^ 
 
-libjas_debug.a: CFLAGS = $(CFLAGS_COMMON) -g -std=c99 -Og
+libjas_debug.a: CFLAGS = $(CFLAGS_COMMON) -g -std=c99 -O0
 libjas_debug.a: $(OBJ)
 	ar rcs $(BUILD)/$@ $^
 
 # Individual object files rules:
-operand_cpp.o: CFLAGS = $(CFLAGS_COMMON) -std=c++11 -O3
+operand_cpp.o: CFLAGS = $(CFLAGS_COMMON) -std=c++11 -O0
 operand_cpp.o: operand.cpp
 	$(CC) $(CFLAGS) -c $< -o $@	

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 CC = clang
 
-CFLAGS_COMMON = -I ../libjas/include -I ../libjas/ -lstdc++ -g -Og
+CFLAGS_COMMON = -I ../libjas/include -I ../libjas/ -lstdc++ -g -O0
 CFLAGS = $(CFLAGS_COMMON)
 
 TESTS = $(patsubst %.c, %, $(wildcard *.c)) 


### PR DESCRIPTION
After the addition of the `-Og` compiler flags in commit number 84908117baa3292d46ffc9cae7a5d4b4adf82e89, the lldb debugger has complained about a compiler optimsation issue and that many expression and variable evaluation functionality can be limited as documented in the llvm docs.