### PR TITLE
Minor patch: Modified guard to correct operand sizes

### DIFF
--- a/libjas/pre.c
+++ b/libjas/pre.c
@@ -33,10 +33,8 @@ DEFINE_PRE_ENCODER(same_operand_sizes) {
 }
 
 DEFINE_PRE_ENCODER(pre_imm) {
-  if (op_sizeof(op_arr[0].type) != 64) {
-    same_operand_sizes(op_arr, buf, instr_ref, mode);
-    return;
-  }
+  if (op_sizeof(op_arr[1].type) == 64) err("64-bit immediate is not allowed.");
+  if (op_acc(op_arr[0].type)) same_operand_sizes(op_arr, buf, instr_ref, mode);
 }
 
 DEFINE_PRE_ENCODER(pre_jcc_no_byte) {


### PR DESCRIPTION
This pull has modified the `pre_imm` pre-processor function to allow many operand sizes where there is NOT an accumulator register, and also added a guard to prevent 64-bit sized immediate operands in the *second operand* position. As described in the `SUB` instruction of the Intel x64 manual, the MI opcode identity should not include a 64-bit corrisponding operand even though the first operand is a 64-bit memory location and shall follow the identity as described:

  > Op/En  Operand 1            Operand 2
  > MI	   ModRM:r/m (r, w)	imm8/16/32

Now, the encodings seems to be matching to the intel manual and the corrisponding encoded format of the instruction: `sub rax, 0x12345678` *does infact disassemble correctly*.