### PR TITLE
Modifications to enocder lookups

### DIFF
--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -41,6 +41,7 @@ typedef struct operand operand_t;
  * methods in the main source file - `encoder.c`.
  */
 enum enc_ident {
+  ENC_NULL,
   ENC_MR,
   ENC_RM,
   ENC_OI,

--- a/libjas/include/operand.h
+++ b/libjas/include/operand.h
@@ -141,7 +141,7 @@ void op_write_prefix(buffer_t *buf, const operand_t *op_arr, enum modes mode);
  * @param input The input operand list
  * @return The operand identity enumeration
  */
-enum enc_ident op_ident_identify(enum operands *input);
+enum enc_ident op_ident_identify(enum operands *input, instr_encode_table_t *instr_ref);
 
 /**
  * Simple function for determining the ModR/M mode based on the

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -52,14 +52,10 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
       instr.operands[0].type, instr.operands[1].type,
       instr.operands[2].type, instr.operands[3].type,
   };
-
   // clang-format on
 
-  enum enc_ident ident = op_ident_identify(operand_list);
-  if (ident == ENC_MR && op_r(operand_list[0])) ident = ENC_RM;
-  // TODO Edge case for MOV instruction - Work on in future
-  if (instr.instr == INSTR_MOV)
-    if (ident == ENC_MI) ident = ENC_OI;
+  enum enc_ident ident =
+      op_ident_identify(operand_list, instr_table[(size_t)instr.instr]);
 
   for (uint8_t j = 0; CURR_TABLE.opcode_size; j++)
     if (CURR_TABLE.ident == ident) return CURR_TABLE;


### PR DESCRIPTION
This pull has addressed some long-term issues with using a "free for all" unordered map that frequenty find issues with incorrect enocdings and *un-optimised* enocder identies and previously needing a if statement to manually correct for it after the operation.

After this change, **everything** is stored in a single *`multimap`*, given a instruction reference passed into the function, the implemented `op_ident_identify` function will rule out any edge cases that are not shown inside the provided table, reducing chances of a mis-hap.