### PR TITLE
Added filler element for `enum instructions`

### DIFF
--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -50,6 +50,7 @@ typedef struct instr_encode_table instr_encode_table_t;
 #define INSTR_DIRECTIVE(i) ((uint8_t)i > (uint8_t)INSTR_DUMMY)
 
 enum instructions {
+  INSTR_NOTHING, /* Note naming conflict below `INSTR_NULL` */
   INSTR_MOV,
   INSTR_LEA,
   INSTR_ADD,

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -136,7 +136,7 @@ typedef struct {
   }
 
 #define INSTR_NULL \
-  (instruction_t) { .instr = NULL, .operands = NULL }
+  (instruction_t) { .instr = INSTR_NOTHING, .operands = NULL }
 
 // Macro for checking if the instruction is a label and shall be handled
 #define IS_LABEL(x)                                     \

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -36,7 +36,7 @@
 
 instr_encode_table_t *instr_table[] =
     {
-        mov, lea, add, sub, mul, _div, and, or, xor, _not, inc,
+        NULL, mov, lea, add, sub, mul, _div, and, or, xor, _not, inc,
         dec, jmp, je, jne, jz, jnz, call, ret, cmp, push, pop,
         in, out, clc, stc, cli, sti, nop, hlt, _int, syscall, 
         movzx, movsx, xchg, bswap,
@@ -46,7 +46,7 @@ instr_encode_table_t *instr_table[] =
 #define CURR_TABLE instr_table[instr.instr][j]
 
 instr_encode_table_t instr_get_tab(instruction_t instr) {
-  if (instr.instr == NULL && instr.operands == NULL) return INSTR_TAB_NULL;
+  if (instr.instr == INSTR_NOTHING && instr.operands == NULL) return INSTR_TAB_NULL;
   if (INSTR_DIRECTIVE(instr.instr)) return INSTR_TAB_NULL; // aka empty
   const enum operands operand_list[4] = {
       instr.operands[0].type, instr.operands[1].type,

--- a/tests/operand.c
+++ b/tests/operand.c
@@ -44,7 +44,7 @@ Test(operand, construct_operand) {
   assert_eq(*(unsigned char *)byte.data, 0xFF);
 }
 
-#define sample_tab instr_table[0] /* Corresponds to the `mov` table */
+#define sample_tab instr_table[1] /* Corresponds to the `mov` table */
 Test(operand, ident_identify) {
   const enum operands input[] = {OP_R8, OP_R16, OP_NULL, OP_NULL};
   const enum operands input2[] = {OP_R8, OP_M16, OP_NULL, OP_NULL};


### PR DESCRIPTION
In the previous code (as shown in the patch file), the `instr_get_tab` function attemps to compare the `instr.instr` enumeration to the constance `NULL` value. Since the `NULL` value equates to the `INSTR_MOV` enum, it may cause incorrect readings and a compiler error as well 😝.

This pull has added a `INSTR_NOTHING` value to the `instructions` enum to seperate values and allow debugging processes to directly and clearly identify if an instruction is invalid, instead of defaulting to `MOV`.