### PR TITLE
Fixed type cast issue

### DIFF
--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -70,7 +70,7 @@ static void write_offset(uint8_t mode, buffer_t *buf, operand_t *op_arr, uint8_t
 
 DEFINE_ENCODER(i) {
   //  Error checking - A register only & only 8, 16, 32 bit-sized operands
-  if (reg_lookup_val(op_arr[0].data) != 0 && !reg_needs_rex((enum registers)op_arr[0].data)) {
+  if (reg_lookup_val(op_arr[0].data) != 0 && !reg_needs_rex(*(enum registers *)op_arr[0].data)) {
     err("Instruction identity must use an \"A\" register!");
     return;
   }


### PR DESCRIPTION
In this pull, a previously not dereferenced pointer has been forced and casted into the `reg_needs_rex` funciton as shown below:
>``` !reg_needs_rex((enum registers)op_arr[0].data)```

This is immediately incorrect as a memory address may **not** just magically turn into a register, not without a de-reference to the pointer. This is further pronounced when we see that the function **itself** does not allow a pointer to be passed, so having a pointer forced into there is **very very very dangerous** (This is why we have rust lol 🦀).