### PR TITLE
Updated macro

### DIFF
--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -66,11 +66,11 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
 }
 #undef CURR_TABLE
 
-#define alloc_operand_data(type)          \
-  do {                                    \
-    type *type##_ = malloc(sizeof(type)); \
-    *type##_ = va_arg(args, type);        \
-    data = (void *)type##_;               \
+#define alloc_operand_data(type)             \
+  do {                                       \
+    type *type##_ = malloc(sizeof(type));    \
+    *type##_ = (type)va_arg(args, uint64_t); \
+    data = (void *)type##_;                  \
   } while (0);
 
 /* Stupid almost-stub implementation */


### PR DESCRIPTION
This commit has updated the `alloc_operand_data` macro to allow it to safely allocate enough data when "popping" an argument from the stack for. Previously, the `va_arg` macro would promote some data sizes as `int`s and messing up other data types. This commit has just added a little "one size fits all" solution by allocating a 64-bit sized parameter.