### PR TITLE
Op modrm mode fix

### DIFF
--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -66,11 +66,11 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
 }
 #undef CURR_TABLE
 
-#define alloc_operand_data(type)          \
-  do {                                    \
-    type *type##_ = malloc(sizeof(type)); \
-    *type##_ = va_arg(args, type);        \
-    data = (void *)type##_;               \
+#define alloc_operand_data(type)             \
+  do {                                       \
+    type *type##_ = malloc(sizeof(type));    \
+    *type##_ = (type)va_arg(args, uint64_t); \
+    data = (void *)type##_;                  \
   } while (0);
 
 /* Stupid almost-stub implementation */

--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -34,7 +34,7 @@ uint8_t op_modrm_mode(operand_t input) {
   register const enum registers deref_reg = (*(enum registers *)input.data);
   if (reg_lookup_val(input.data) == 5 && !reg_needs_rex(deref_reg)) {
     if (deref_reg == REG_RIP || deref_reg == REG_EIP || deref_reg == REG_IP) {
-      if (op_r(deref_reg))
+      if (op_r(input.type))
         err("RIP, EIP and IP cannot be used as direct operands.");
       return OP_MODRM_INDIRECT;
     } else if (input.offset == 0)


### PR DESCRIPTION
Previously, `op_modrm_mode()` function used a `op_r` macro (as
defined and documented in `operand.h`) to determine if a indirect/
direct register operand is used. However, this was incorrectly
invoked and caused a compiler warning, which was ignored. This pull
has changed the register value to the *correct* operand.
