### PR TITLE
Added support for IN and OUT instructions

### DIFF
--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -245,7 +245,14 @@ DEFINE_ENCODER(zo) {
   buf_write(buf, instr_ref->opcode, instr_ref->opcode_size);
 }
 
+DEFINE_ENCODER(ign) {
+  if (op_sizeof(op_arr[0].type) == 8 && instr_ref->has_byte_opcode)
+    buf_write(buf, instr_ref->byte_instr_opcode, instr_ref->opcode_size);
+  else
+    zo(op_arr, buf, instr_ref, mode);
+}
+
 encoder_t enc_lookup(enum enc_ident input) {
-  encoder_t lookup[] = {NULL, &mr, &rm, &oi, &mi, &i, &m, &zo, &d, &o};
+  encoder_t lookup[] = {NULL, &mr, &rm, &oi, &mi, &i, &m, &zo, &d, &o, &ign};
   return lookup[(size_t)input];
 }

--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -51,6 +51,8 @@ enum enc_ident {
   ENC_ZO,
   ENC_D,
   ENC_O,
+  ENC_IGN, /* Although **NOT** original Intel, this identity will
+              void all operands, directs to the ZO identity. */
 };
 
 /**

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -169,5 +169,6 @@ void instr_free(instruction_t *instr) {
     if (instr->operands[i].type) free(instr->operands[i].data);
   }
 
+  free(instr->operands);
   free(instr);
 }

--- a/libjas/operand.cpp
+++ b/libjas/operand.cpp
@@ -95,6 +95,11 @@ extern "C" enum enc_ident op_ident_identify(enum operands *input, instr_encode_t
   if (lookup_table.find(hash_key) != lookup_table.end()) {
     return lookup_table.find(hash_key)->second;
   } else {
+    uint8_t k = 0;
+    while (instr_ref[k].opcode_size) {
+      if (instr_ref[k].ident == ENC_IGN) return ENC_IGN;
+      k++;
+    } /* Fall though: */
     err("No corresponding instruction opcode found.");
     return ENC_NULL;
   }

--- a/libjas/pre.c
+++ b/libjas/pre.c
@@ -1,5 +1,6 @@
 #include "error.h"
 #include "operand.h"
+#include "register.h"
 
 #define DEFINE_PRE_ENCODER(name) \
   static void name(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode)
@@ -66,4 +67,13 @@ DEFINE_PRE_ENCODER(pre_cmov) {
       break;
     }
   }
+}
+
+DEFINE_PRE_ENCODER(pre_in_out) {
+  const enum registers reg = *(enum registers *)op_arr[0].data;
+  if (reg != REG_AL && reg != REG_AX && reg != REG_EAX)
+    err("Invalid operand for IN/OUT instruction.");
+
+  if (op_sizeof(op_arr[1].type) > 16 && *(enum registers *)op_arr[1].data != REG_DX)
+    err("Byte or `dx` operands needs to be used with the IN/OUT instruction.");
 }

--- a/libjas/tabs.c
+++ b/libjas/tabs.c
@@ -84,8 +84,17 @@ DEFINE_TAB(pop) = {
     INSTR_TAB_NULL,
 };
 
-DEFINE_TAB(in) = {{}};
-DEFINE_TAB(out) = {{}};
+DEFINE_TAB(in) = {
+    {ENC_OI, NULL, {0xE5}, MODE_SUPPORT_ALL, {0xE4}, 1, &pre_in_out, true},
+    {ENC_IGN, NULL, {0xED}, MODE_SUPPORT_ALL, {0xEC}, 1, &pre_in_out, true},
+    INSTR_TAB_NULL,
+};
+
+DEFINE_TAB(out) = {
+    {ENC_OI, NULL, {0xE7}, MODE_SUPPORT_ALL, {0xE6}, 1, &pre_in_out, true},
+    {ENC_IGN, NULL, {0xEF}, MODE_SUPPORT_ALL, {0xEE}, 1, &pre_in_out, true},
+    INSTR_TAB_NULL,
+};
 
 #define ZO_GENERIC(opcode) \
   {ENC_ZO, NULL, {opcode}, MODE_SUPPORT_ALL, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL


### PR DESCRIPTION
This pull has added the support for the IN and OUT instructions in the Jas assembler, due to the unusual patterns of the encoding as documented in the Intel documentation, this instruction has been put off, and I've procrastinated for quite a while of adding the support for this instruction. Inparticular, instruction has non- standard operand encodin identity formats where the ZO identity was used to depict the use of the DX and AL *registers*, which **had operands**. (See the extact from below)

> Instruction	Op/En		64-Bit Mode
> EF		OUT DX, EAX	ZO

Since the in-consistency, a new encoder identity was implemented in this pull, namely a `ENC_IGN` idenity that is used as a little *default* value *other than* the `NULL` value, as seen in previous commits. This encoder identity will **ignore** all operands and just encode the operand, passing jobs onto other enocders which; matches the needs and requirements of the IN and OUT instructions' encodings.