### PR TITLE
Removed the usage of the accumulator operand type

### DIFF
--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -248,19 +248,18 @@ instruction_t *instr_write_bytes(size_t data_sz, ...);
 #define m64(x, off) OP_M64, x, off
 
 /**
- * Not to be confused with the `r8` and other operand macros, this
- * macro is used to define the accumulator register operand in the
- * instruction. Like rax, eax etc. This wouldn't work when used with
- * instructions that dont support the accumulator register.
+ * This macro is used to define the accumulator register operand in the
+ * instruction. Like rax, eax etc. This operand will work in-place of of
+ * the r16(REG_AX) for example.
  *
  * Check the Intel manual, whatever the intel manual says is as a valid
  * accumulator is the default implemented version.
  */
 
-#define acc8 OP_ACC8, REG_AL, 0
-#define acc16 OP_ACC16, REG_AX, 0
-#define acc32 OP_ACC32, REG_EAX, 0
-#define acc64 OP_ACC64, REG_RAX, 0
+#define acc8 OP_R8, REG_AL, 0
+#define acc16 OP_R16, REG_AX, 0
+#define acc32 OP_R32, REG_EAX, 0
+#define acc64 OP_R64, REG_RAX, 0
 
 /**
  * A function for easily defining a instruction in the `instruction_t`

--- a/libjas/include/operand.h
+++ b/libjas/include/operand.h
@@ -79,10 +79,6 @@ enum operands {
   OP_M16,
   OP_M32,
   OP_M64,
-  OP_ACC8,
-  OP_ACC16,
-  OP_ACC32,
-  OP_ACC64,
 };
 
 /**
@@ -103,14 +99,13 @@ enum operands {
 #define op_r(x) ((x) <= OP_R64 && (x) >= OP_R8)
 #define op_imm(x) ((x) <= OP_IMM64 && (x) >= OP_IMM8)
 #define op_m(x) ((x) <= OP_M64 && (x) >= OP_M8)
-#define op_acc(x) ((x) <= OP_ACC64 && (x) >= OP_ACC8)
 
 // --
 
-#define op_byte(x) (x == OP_REL8 || x == OP_R8 || x == OP_IMM8 || x == OP_M8 || x == OP_ACC8)
-#define op_word(x) (x == OP_REL16 || x == OP_R16 || x == OP_IMM16 || x == OP_M16 || x == OP_ACC16)
-#define op_dword(x) (x == OP_REL32 || x == OP_R32 || x == OP_IMM32 || x == OP_M32 || x == OP_ACC32)
-#define op_qword(x) (x == OP_R64 || x == OP_IMM64 || x == OP_M64 || x == OP_ACC64)
+#define op_byte(x) (x == OP_REL8 || x == OP_R8 || x == OP_IMM8 || x == OP_M8)
+#define op_word(x) (x == OP_REL16 || x == OP_R16 || x == OP_IMM16 || x == OP_M16)
+#define op_dword(x) (x == OP_REL32 || x == OP_R32 || x == OP_IMM32 || x == OP_M32)
+#define op_qword(x) (x == OP_R64 || x == OP_IMM64 || x == OP_M64)
 
 // --
 

--- a/libjas/include/operand.hpp
+++ b/libjas/include/operand.hpp
@@ -67,6 +67,5 @@ typedef uint8_t op_ident_hash_t;
 #define OP_HASH_R 0b00000010
 #define OP_HASH_IMM 0b00000100
 #define OP_HASH_M 0b00001000
-#define OP_HASH_ACC 0b00100000
 
 #endif

--- a/libjas/include/register.h
+++ b/libjas/include/register.h
@@ -225,4 +225,7 @@ uint8_t reg_lookup_val(enum registers *input);
  */
 bool reg_needs_rex(enum registers input);
 
+// Orphan macro for checking if the operand data is used as accumulator register.
+#define op_acc(x) ((x) == REG_AL || (x) == REG_AX || (x) == REG_EAX || (x) == REG_RAX)
+
 #endif

--- a/libjas/operand.cpp
+++ b/libjas/operand.cpp
@@ -50,7 +50,6 @@ static op_ident_hash_t op_hash(enum operands input) {
   if (op_r(input)) return OP_HASH_R;
   if (op_imm(input)) return OP_HASH_IMM;
   if (op_m(input)) return OP_HASH_M;
-  if (op_acc(input)) return OP_HASH_ACC;
 
   return OP_HASH_NONE;
 }
@@ -66,7 +65,7 @@ static multimap<enum enc_ident, uint32_t> master = {
     {ENC_MI, __combine__(OP_HASH_M, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE)},
 
     {ENC_ZO, __combine__(OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE)},
-    {ENC_O, __combine__(OP_HASH_ACC, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE)},
+    {ENC_O, __combine__(OP_HASH_R, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE)},
     {ENC_I, __combine__(OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE)},
     {ENC_D, __combine__(OP_HASH_REL, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE)},
 

--- a/libjas/pre.c
+++ b/libjas/pre.c
@@ -1,4 +1,5 @@
 #include "error.h"
+#include "instruction.h"
 #include "operand.h"
 #include "register.h"
 
@@ -35,7 +36,9 @@ DEFINE_PRE_ENCODER(same_operand_sizes) {
 
 DEFINE_PRE_ENCODER(pre_imm) {
   if (op_sizeof(op_arr[1].type) == 64) err("64-bit immediate is not allowed.");
-  if (op_acc(op_arr[0].type)) same_operand_sizes(op_arr, buf, instr_ref, mode);
+  const enum registers register_data = *(enum registers *)op_arr[0].data; // Get the register data
+  if (op_acc(register_data)) same_operand_sizes(op_arr, buf, instr_ref, mode);
+  if (instr_ref->ident == ENC_OI && !op_acc(register_data)) err("Invalid operand for this instruction.");
 }
 
 DEFINE_PRE_ENCODER(pre_jcc_no_byte) {


### PR DESCRIPTION
This pull has removed the usage of the accumulator type such as the `OP_ACC64` and others in favor of using the already frequently used `OP_R64` and simply subbing in the `REG_RAX` value instead, also al- lowing the usage of the `acc` macro in other situations other than the supported instructions. Using these new operand types not only allows for more flexibility but also gives the same error handling the `REG` module would otherwise, allowing more common ground between types.