### PR TITLE
Make assembler labels 'first class symbols'

### DIFF
--- a/libjas/include/label.h
+++ b/libjas/include/label.h
@@ -30,24 +30,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-/**
- * Function for creating a new label with the given name and address
- * as mentioned in the `label_t` struct, storing it in an internal
- * table as a label entry.
- *
- * @param name The name of the label.
- * @param exported Boolean for whether the label is exported or not.
- * @param ext Boolean for whether the label is external or not.
- * @param address The address of the label.
- *
- * @note The address depicts a position in the buffer, and can be
- * obtained using `buf.len` after encoding the instruction from
- * the `buffer.h`, or many times the `buf` variable. Therefore,
- * allowing the relative addressing of the label to be calculated
- * on the fly.
- */
-void label_create(char *name, bool exported, bool ext, size_t address);
-
 typedef struct {
   char *name;     /* Name of the label in a string format */
   bool exported;  /* Boolean for whether the label is exported to the linker table or not */
@@ -55,33 +37,50 @@ typedef struct {
   size_t address; /* Address of the label entry, can use `buf.len` */
 } label_t;
 
-size_t label_get_size();
-label_t *label_get_table();
+/**
+ * A factory function for creating a label entry in the label table.
+ * The label entry is a struct that contains the name of the label,
+ * whether it is exported or not, whether it is external or not, and
+ * the address of the label. This data is constructed and then stored
+ * into the given table pointer.
+ *
+ * @param label_table The label table to store the label entry in.
+ * @param label_table_size The size of the label table.
+ *
+ * @param name The name of the label.
+ * @param exported Boolean for whether the label is exported or not.
+ * @param ext Boolean for whether the label is external or not.
+ * @param address The address of the label.
+ */
+void label_create(
+    label_t **label_table, size_t *label_table_size,
+    char *name, bool exported, bool ext, size_t address);
 
 /**
  * Function for destroying the label table, freeing the memory
  * allocated for the label names and the label entries itself.
  *
- * @warning This function will free all the memory allocated for
- * the label entries and the label names, and will set the label
- * table to `NULL` and the label table size to `0`. Potentially
- * destructive!
+ * @param label_table The label table to destroy.
+ * @param label_table_size The size of the label table
  */
-void label_destroy_all();
+void label_destroy_all(label_t **label_table, size_t *label_table_size);
 
 /**
  * Function for looking up a label in the label table, and retu-
  * rning the label entry if found, otherwise returning a `NULL`
  * label entry will be returned back to the caller.
  *
+ * @param label_table The label table to look up the label in.
+ * @param label_table_size The size of the label table.
+ *
  * @param name The name of the label to look up in the label table.
- *
- * @note Caller is responsible for freeing the memory allocated
- * and handling string creations and declarations.
- *
  * @return The pointer to the label entry if found, otherwise `NULL`
+ *
+ * @note The label table is **assumed** to be allocated and setup
+ * correctly before calling this function, stored in the `label_table`
+ * and `label_table_size` pointers (as shown above).
  */
-label_t *label_lookup(char *name);
+label_t *label_lookup(label_t **label_table, size_t *label_table_size, char *name);
 
 /**
  * Enumeration for expressing the different types of labels used

--- a/libjas/label.c
+++ b/libjas/label.c
@@ -31,11 +31,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-static label_t *label_table = NULL;
-static size_t label_table_size = 0;
+void label_create(
+    label_t **label_table, size_t *label_table_size,
+    char *name, bool exported, bool ext, size_t address) {
 
-void label_create(char *name, bool exported, bool ext, size_t address) {
-  if (label_lookup(name) != NULL) {
+  if (label_lookup(label_table, label_table_size, name) != NULL) {
     err("Label conflict detected, a duplicate cannot be created.");
     return;
   }
@@ -46,30 +46,27 @@ void label_create(char *name, bool exported, bool ext, size_t address) {
      .address = address, };
   // clang-format on
 
-  label_table_size++;
+  *label_table_size++;
   label_table = (label_t *)
-      realloc(label_table, label_table_size * sizeof(label_t));
+      realloc(label_table, *label_table_size * sizeof(label_t));
 
-  label_table[label_table_size - 1] = label;
+  *(label_table)[*label_table_size - 1] = label;
 }
 
-void label_destroy_all() {
+void label_destroy_all(label_t **label_table, size_t *label_table_size) {
   free(label_table);
 
   label_table = NULL;
-  label_table_size = 0;
+  *(label_table_size) = 0;
 }
 
-label_t *label_lookup(char *name) {
-  for (size_t i = 0; i < label_table_size; i++)
-    if (strcmp(label_table[i].name, name) == 0)
-      return &label_table[i];
+label_t *label_lookup(label_t **label_table, size_t *label_table_size, char *name) {
+  for (size_t i = 0; i < *label_table_size; i++)
+    if (strcmp(label_table[i]->name, name) == 0)
+      return label_table[i];
 
   return NULL;
 }
-
-size_t label_get_size() { return label_table_size; }
-label_t *label_get_table() { return label_table; }
 
 instruction_t *label_gen(char *name, enum label_type type) {
   enum instructions instr = INSTR_DIR_LOCAL_LABEL;


### PR DESCRIPTION
This pull is aimed as reducing the previous 'monopoly' of the label module where previously, the labels are stored ina global variable and tracked that way using certain utility function. This solution is fine, but causes *few* problems:

a) **Thread safety**, If we wanted to multithread this or use this in specific applications where somehow multihtreading or race-conditions can potentially be critical, this dis-qualifies it as "safe"

b) **Flexibility**, having everything (labels and symbols) being cooped up into one little "cubby" prevents the user and dis-allows control, un- less if they come into the source code and get their hands dirty, which in my opinion is un-disierable, for both programmers and users, where wrappers and everything has to be strangely "pushed into eachother".

c) **Maintance & re-useability**. similar in terms of *flexibility*, having more flexibility allows the module to be packaged more snuggly and allow it to be re-used in other functions or applications, if needed (later down the road)

---

This pull achomplish this by having many functions pass-in a `label_table` and corrisponding size to do the operations on. Also, older software must also be altered to support dependencies of this new function.