### PR TITLE
Remove strdup for malloc

### DIFF
--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -96,7 +96,11 @@ instruction_t *instr_gen(enum instructions instr, uint8_t operand_count, ...) {
     void *data;
     if (op_rel(type)) {
       char *lab = va_arg(args, char *);
-      label = strdup(lab);
+      const size_t label_name_size = strlen(lab) + 1;
+      char *copied_name = malloc(label_name_size);
+      strcpy(copied_name, lab);
+      
+      label = copied_name;
 
       // clang-format off
     } else if (op_imm(type)) {

--- a/libjas/label.c
+++ b/libjas/label.c
@@ -83,9 +83,12 @@ instruction_t *label_gen(char *name, enum label_type type) {
   }
   // clang-format on
 
-  name = strdup(name);
+  const size_t label_name_size = strlen(name) + 1;
+  char *copied_name = malloc(label_name_size);
+  strcpy(copied_name, name);
+
   operand_t *operands = calloc(4, sizeof(operand_t));
-  operands[0] = op_construct_operand(OP_MISC, 0, name, NULL);
+  operands[0] = op_construct_operand(OP_MISC, 0, copied_name, NULL);
 
   instruction_t *instr_ret = malloc(sizeof(instruction_t));
   *instr_ret = (instruction_t){


### PR DESCRIPTION
Experimental: Utilise `malloc` instead of `strdup`
    
There have been portability issues associated with the (although C
standard) `strdup` funciton, which apparently is un-defined on linux
systems. This commit has opted to use the standard `malloc` and `strcpy`
it over to the destination.