### PR TITLE
Changed `has_byte_opcode` into size field

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ DEFINE_TAB(new_ent) = {{
   .byte_instr_opcode     = {0xfa},
   .opcode_size           = 1,
   .pre                   = NULL,
-  .has_byte_opcode       = true,
+  .byte_opcode_size      = 1,
 }};
 
 // `new_ent` will be added to an array of different instruction identities.

--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -218,18 +218,7 @@ DEFINE_ENCODER(oi) {
   i_common(op_arr, buf, instr_ref, mode);
 }
 
-DEFINE_ENCODER(zo) {
-  buf_write(buf, instr_ref->opcode, instr_ref->opcode_size);
-}
-
-DEFINE_ENCODER(ign) {
-  if (op_sizeof(op_arr[0].type) == 8 && instr_ref->has_byte_opcode)
-    buf_write(buf, instr_ref->byte_instr_opcode, instr_ref->opcode_size);
-  else
-    zo(op_arr, buf, instr_ref, mode, label_table, label_table_size);
-}
-
 encoder_t enc_lookup(enum enc_ident input) {
-  encoder_t lookup[] = {NULL, &mr, &rm, &oi, &mi, &i, &m, &zo, &d, &o, &ign};
+  encoder_t lookup[] = {NULL, &mr, &rm, &oi, &mi, &i, &m, NULL, &d, &o, NULL};
   return lookup[(size_t)input];
 }

--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -53,7 +53,7 @@ enum enc_ident {
   ENC_D,
   ENC_O,
   ENC_IGN, /* Although **NOT** original Intel, this identity will
-              void all operands, directs to the ZO identity. */
+  void all operands, only writing the opcode (IGN meaning *ignore*) */
 };
 
 /**

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -134,7 +134,7 @@ struct instr_encode_table {
   uint8_t byte_instr_opcode[3]; /* 8 bit opcode fallback of the instruction */
   uint8_t opcode_size;          /* Size of the opcode (max. 3 bytes)*/
   pre_encoder_t pre;            /* Pre-encoder processor function (Optional, null if not applicable) */
-  bool has_byte_opcode;         /* If the instruction encoder table has a byte instruction opcode */
+  uint8_t byte_opcode_size;     /* Size of the byte opcode (max. 3 bytes, may be left null) */
 };
 
 /**
@@ -156,7 +156,7 @@ typedef struct instruction {
     .byte_instr_opcode = {NULL}, \
     .opcode_size = NULL,         \
     .pre = NULL,                 \
-    .has_byte_opcode = false     \
+    .byte_opcode_size = NULL,    \
   }
 
 #define INSTR_NULL \

--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -66,7 +66,7 @@ uint8_t op_sizeof(enum operands input) {
 }
 
 uint8_t *op_write_opcode(operand_t *op_arr, instr_encode_table_t *instr_ref) {
-  if (!instr_ref->has_byte_opcode) return instr_ref->opcode;
+  if (instr_ref->byte_opcode_size > 0) return instr_ref->opcode;
   for (uint8_t i = 0; i < 4; i++) {
     if (op_arr[i].type == OP_NULL) break;
     if (op_byte(op_arr[i].type)) return instr_ref->byte_instr_opcode;

--- a/libjas/tabs.c
+++ b/libjas/tabs.c
@@ -38,176 +38,176 @@
 #include "pre.c"
 
 instr_encode_table_t mov[] = {
-    {ENC_MR, NULL, {0x89}, {0x88}, 1, &same_operand_sizes, true},
-    {ENC_RM, NULL, {0x8B}, {0x8A}, 1, &same_operand_sizes, true},
+    {ENC_MR, NULL, {0x89}, {0x88}, 1, &same_operand_sizes, 1},
+    {ENC_RM, NULL, {0x8B}, {0x8A}, 1, &same_operand_sizes, 1},
     {ENC_OI, NULL, {0xB8}, {0xB0}, 1, &same_operand_sizes},
-    {ENC_MI, 0b10000000, {0xC7}, {0xC6}, 1, &pre_imm, true},
+    {ENC_MI, 0b10000000, {0xC7}, {0xC6}, 1, &pre_imm, 1},
 
     INSTR_TAB_NULL,
 };
-instr_encode_table_t lea[] = {{ENC_RM, NULL, {0x8D}, {0x8D}, 1, &pre_lea, true}, INSTR_TAB_NULL};
+instr_encode_table_t lea[] = {{ENC_RM, NULL, {0x8D}, {0x8D}, 1, &pre_lea, 1}, INSTR_TAB_NULL};
 
 instr_encode_table_t add[] = {
-    {ENC_RM, NULL, {0x03}, {0x02}, 1, &same_operand_sizes, true},
-    {ENC_MR, NULL, {0x01}, {0x00}, 1, &same_operand_sizes, true},
-    {ENC_I, NULL, {0x03}, {0x02}, 1, &pre_imm, true},
-    {ENC_MI, 0b10000000, {0x81}, {0x80}, 1, &pre_imm, true},
+    {ENC_RM, NULL, {0x03}, {0x02}, 1, &same_operand_sizes, 1},
+    {ENC_MR, NULL, {0x01}, {0x00}, 1, &same_operand_sizes, 1},
+    {ENC_I, NULL, {0x03}, {0x02}, 1, &pre_imm, 1},
+    {ENC_MI, 0b10000000, {0x81}, {0x80}, 1, &pre_imm, 1},
     INSTR_TAB_NULL,
 };
 instr_encode_table_t sub[] = {
-    {ENC_RM, NULL, {0x2B}, {0x2A}, 1, &same_operand_sizes, true},
-    {ENC_MR, NULL, {0x28}, {0x29}, 1, &same_operand_sizes, true},
-    {ENC_I, NULL, {0x2C}, {0x2D}, 1, &pre_imm, true},
-    {ENC_MI, 5, {0x81}, {0x80}, 1, &pre_imm, true},
+    {ENC_RM, NULL, {0x2B}, {0x2A}, 1, &same_operand_sizes, 1},
+    {ENC_MR, NULL, {0x28}, {0x29}, 1, &same_operand_sizes, 1},
+    {ENC_I, NULL, {0x2C}, {0x2D}, 1, &pre_imm, 1},
+    {ENC_MI, 5, {0x81}, {0x80}, 1, &pre_imm, 1},
     INSTR_TAB_NULL,
 };
-instr_encode_table_t mul[] = {{ENC_M, 4, {0xF7}, {0xF6}, 1, &same_operand_sizes, true}, INSTR_TAB_NULL};
-instr_encode_table_t _div[] = {{ENC_M, 6, {0xF7}, {0xF6}, 1, &same_operand_sizes, true}, INSTR_TAB_NULL};
+instr_encode_table_t mul[] = {{ENC_M, 4, {0xF7}, {0xF6}, 1, &same_operand_sizes, 1}, INSTR_TAB_NULL};
+instr_encode_table_t _div[] = {{ENC_M, 6, {0xF7}, {0xF6}, 1, &same_operand_sizes, 1}, INSTR_TAB_NULL};
 
 instr_encode_table_t and[] = {
-    {ENC_RM, NULL, {0x23}, {0x22}, 1, &same_operand_sizes, true},
-    {ENC_MR, NULL, {0x21}, {0x20}, 1, &same_operand_sizes, true},
-    {ENC_I, NULL, {0x25}, {0x24}, 1, &pre_imm, true},
-    {ENC_MI, 4, {0x81}, {0x80}, 1, &pre_imm, true},
+    {ENC_RM, NULL, {0x23}, {0x22}, 1, &same_operand_sizes, 1},
+    {ENC_MR, NULL, {0x21}, {0x20}, 1, &same_operand_sizes, 1},
+    {ENC_I, NULL, {0x25}, {0x24}, 1, &pre_imm, 1},
+    {ENC_MI, 4, {0x81}, {0x80}, 1, &pre_imm, 1},
     INSTR_TAB_NULL,
 };
 instr_encode_table_t or [] = {
-    {ENC_RM, NULL, {0x0B}, {0x0A}, 1, &same_operand_sizes, true},
-    {ENC_MR, NULL, {0x09}, {0x08}, 1, &same_operand_sizes, true},
-    {ENC_I, NULL, {0x0D}, {0x0C}, 1, &pre_imm, true},
-    {ENC_MI, 1, {0x81}, {0x80}, 1, &pre_imm, true},
+    {ENC_RM, NULL, {0x0B}, {0x0A}, 1, &same_operand_sizes, 1},
+    {ENC_MR, NULL, {0x09}, {0x08}, 1, &same_operand_sizes, 1},
+    {ENC_I, NULL, {0x0D}, {0x0C}, 1, &pre_imm, 1},
+    {ENC_MI, 1, {0x81}, {0x80}, 1, &pre_imm, 1},
     INSTR_TAB_NULL,
 };
 instr_encode_table_t xor [] = {
-    {ENC_RM, NULL, {0x33}, {0x32}, 1, &same_operand_sizes, true},
-    {ENC_MR, NULL, {0x31}, {0x30}, 1, &same_operand_sizes, true},
-    {ENC_I, NULL, {0x35}, {0x34}, 1, &pre_imm, true},
-    {ENC_MI, 6, {0x81}, {0x80}, 1, &pre_imm, true},
+    {ENC_RM, NULL, {0x33}, {0x32}, 1, &same_operand_sizes, 1},
+    {ENC_MR, NULL, {0x31}, {0x30}, 1, &same_operand_sizes, 1},
+    {ENC_I, NULL, {0x35}, {0x34}, 1, &pre_imm, 1},
+    {ENC_MI, 6, {0x81}, {0x80}, 1, &pre_imm, 1},
     INSTR_TAB_NULL,
 };
 
-instr_encode_table_t _not[] = {{ENC_M, 2, {0xF7}, {0xF6}, 1, &same_operand_sizes, true}, INSTR_TAB_NULL};
+instr_encode_table_t _not[] = {{ENC_M, 2, {0xF7}, {0xF6}, 1, &same_operand_sizes, 1}, INSTR_TAB_NULL};
 
-instr_encode_table_t inc[] = {{ENC_M, 0, {0xFF}, {0xFE}, 1, &same_operand_sizes, true}, INSTR_TAB_NULL};
-instr_encode_table_t dec[] = {{ENC_M, 1, {0xFF}, {0xFE}, 1, &same_operand_sizes, true}, INSTR_TAB_NULL};
+instr_encode_table_t inc[] = {{ENC_M, 0, {0xFF}, {0xFE}, 1, &same_operand_sizes, 1}, INSTR_TAB_NULL};
+instr_encode_table_t dec[] = {{ENC_M, 1, {0xFF}, {0xFE}, 1, &same_operand_sizes, 1}, INSTR_TAB_NULL};
 
 instr_encode_table_t jmp[] = {
-    {ENC_D, NULL, {0xE9}, {0xEB}, 1, NULL, true},
-    {ENC_M, 4, {0xFF}, {NULL}, 1, &pre_imm, false},
+    {ENC_D, NULL, {0xE9}, {0xEB}, 1, NULL, 1},
+    {ENC_M, 4, {0xFF}, {NULL}, 1, &pre_imm, 0},
     INSTR_TAB_NULL,
 };
 
-instr_encode_table_t je[] = {{ENC_D, NULL, {0x0f, 0x84}, {0x090, 0x74}, 2, NULL, true}, INSTR_TAB_NULL};
-instr_encode_table_t jne[] = {{ENC_D, NULL, {0x0f, 0x85}, {0x00, 0x00}, 2, &pre_jcc_no_byte, true}, INSTR_TAB_NULL};
-instr_encode_table_t jz[] = {{ENC_D, NULL, {0x0f, 0x84}, {0x00, 0x00}, 2, &pre_jcc_no_byte, true}, INSTR_TAB_NULL};
-instr_encode_table_t jnz[] = {{ENC_D, NULL, {0x0f, 0x85}, {0x90, 0x75}, 2, NULL, true}, INSTR_TAB_NULL};
+instr_encode_table_t je[] = {{ENC_D, NULL, {0x0f, 0x84}, {0x74}, 2, NULL, 1}, INSTR_TAB_NULL};
+instr_encode_table_t jne[] = {{ENC_D, NULL, {0x0f, 0x85}, {NULL}, 2, &pre_jcc_no_byte, 0}, INSTR_TAB_NULL};
+instr_encode_table_t jz[] = {{ENC_D, NULL, {0x0f, 0x84}, {NULL}, 2, &pre_jcc_no_byte, 0}, INSTR_TAB_NULL};
+instr_encode_table_t jnz[] = {{ENC_D, NULL, {0x0f, 0x85}, {0x75}, 2, NULL, 1}, INSTR_TAB_NULL};
 
 instr_encode_table_t call[] = {
-    {ENC_D, NULL, {0xE8}, {0xEB}, 1, NULL, true},
-    {ENC_M, 2, {0xFF}, {NULL}, 1, &pre_imm, false},
+    {ENC_D, NULL, {0xE8}, {0xEB}, 1, NULL, 1},
+    {ENC_M, 2, {0xFF}, {NULL}, 1, &pre_imm, 0},
     INSTR_TAB_NULL,
 };
 
 instr_encode_table_t ret[] = {
-    {ENC_ZO, NULL, {0xC3}, {0xC3}, 1, &no_operands, true},
-    {ENC_I, NULL, {0xC2}, {0xC2}, 1, &pre_ret, true},
+    {ENC_ZO, NULL, {0xC3}, {0xC3}, 1, &no_operands, 1},
+    {ENC_I, NULL, {0xC2}, {0xC2}, 1, &pre_ret, 1},
     INSTR_TAB_NULL,
 };
 
 instr_encode_table_t cmp[] = {
-    {ENC_RM, NULL, {0x3B}, {0x3A}, 1, &same_operand_sizes, true},
-    {ENC_MR, NULL, {0x39}, {0x38}, 1, &same_operand_sizes, true},
-    {ENC_I, NULL, {0x3D}, {0x3C}, 1, &pre_imm, true},
-    {ENC_MI, 7, {0x81}, {0x80}, 1, &pre_imm, true},
+    {ENC_RM, NULL, {0x3B}, {0x3A}, 1, &same_operand_sizes, 1},
+    {ENC_MR, NULL, {0x39}, {0x38}, 1, &same_operand_sizes, 1},
+    {ENC_I, NULL, {0x3D}, {0x3C}, 1, &pre_imm, 1},
+    {ENC_MI, 7, {0x81}, {0x80}, 1, &pre_imm, 1},
     INSTR_TAB_NULL,
 };
 
 instr_encode_table_t push[] = {
-    {ENC_M, 6, {0xFF}, NULL, 1, NULL, false},
-    {ENC_O, NULL, {0x50}, NULL, 1, NULL, false},
-    {ENC_I, NULL, {0x68}, {0x6A}, 1, &pre_imm, true},
+    {ENC_M, 6, {0xFF}, NULL, 1, NULL, 0},
+    {ENC_O, NULL, {0x50}, NULL, 1, NULL, 0},
+    {ENC_I, NULL, {0x68}, {0x6A}, 1, &pre_imm, 1},
     INSTR_TAB_NULL,
 };
 
 instr_encode_table_t pop[] = {
-    {ENC_M, 0, {0x8F}, NULL, 1, NULL, false},
-    {ENC_O, NULL, {0x58}, NULL, 1, NULL, false},
+    {ENC_M, 0, {0x8F}, NULL, 1, NULL, 0},
+    {ENC_O, NULL, {0x58}, NULL, 1, NULL, 0},
     INSTR_TAB_NULL,
 };
 
 instr_encode_table_t in[] = {
-    {ENC_OI, NULL, {0xE5}, {0xE4}, 1, &pre_in_out, true},
-    {ENC_IGN, NULL, {0xED}, {0xEC}, 1, &pre_in_out, true},
+    {ENC_OI, NULL, {0xE5}, {0xE4}, 1, &pre_in_out, 1},
+    {ENC_IGN, NULL, {0xED}, {0xEC}, 1, &pre_in_out, 1},
     INSTR_TAB_NULL,
 };
 
 instr_encode_table_t out[] = {
-    {ENC_OI, NULL, {0xE7}, {0xE6}, 1, &pre_in_out, true},
-    {ENC_IGN, NULL, {0xEF}, {0xEE}, 1, &pre_in_out, true},
+    {ENC_OI, NULL, {0xE7}, {0xE6}, 1, &pre_in_out, 1},
+    {ENC_IGN, NULL, {0xEF}, {0xEE}, 1, &pre_in_out, 1},
     INSTR_TAB_NULL,
 };
 
-instr_encode_table_t clc[] = {{ENC_ZO, NULL, {0xF8}, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL};
-instr_encode_table_t stc[] = {{ENC_ZO, NULL, {0xF9}, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL};
-instr_encode_table_t cli[] = {{ENC_ZO, NULL, {0xFA}, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL};
-instr_encode_table_t sti[] = {{ENC_ZO, NULL, {0xFB}, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL};
-instr_encode_table_t nop[] = {{ENC_ZO, NULL, {0x90}, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL};
-instr_encode_table_t hlt[] = {{ENC_ZO, NULL, {0xF4}, {NULL}, 1, &no_operands, false}, INSTR_TAB_NULL};
+instr_encode_table_t clc[] = {{ENC_ZO, NULL, {0xF8}, {NULL}, 1, &no_operands, 0}, INSTR_TAB_NULL};
+instr_encode_table_t stc[] = {{ENC_ZO, NULL, {0xF9}, {NULL}, 1, &no_operands, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cli[] = {{ENC_ZO, NULL, {0xFA}, {NULL}, 1, &no_operands, 0}, INSTR_TAB_NULL};
+instr_encode_table_t sti[] = {{ENC_ZO, NULL, {0xFB}, {NULL}, 1, &no_operands, 0}, INSTR_TAB_NULL};
+instr_encode_table_t nop[] = {{ENC_ZO, NULL, {0x90}, {NULL}, 1, &no_operands, 0}, INSTR_TAB_NULL};
+instr_encode_table_t hlt[] = {{ENC_ZO, NULL, {0xF4}, {NULL}, 1, &no_operands, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t _int[] = {{ENC_I, NULL, {0xCD}, {NULL}, 1, &pre_int, false}, INSTR_TAB_NULL};
+instr_encode_table_t _int[] = {{ENC_I, NULL, {0xCD}, {NULL}, 1, &pre_int, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t syscall[] = {{ENC_ZO, NULL, {0x0F, 0x05}, {NULL}, 2, &same_operand_sizes, false}, INSTR_TAB_NULL};
-instr_encode_table_t movzx[] = {{ENC_RM, NULL, {0x0F, 0xB7}, {0x0F, 0xB6}, 2, &pre_small_operands, true}, INSTR_TAB_NULL};
-instr_encode_table_t movsx[] = {{ENC_RM, NULL, {0x0F, 0xBF}, {0x0F, 0xBE}, 2, &pre_small_operands, true}, INSTR_TAB_NULL};
+instr_encode_table_t syscall[] = {{ENC_ZO, NULL, {0x0F, 0x05}, {NULL}, 2, &same_operand_sizes, 0}, INSTR_TAB_NULL};
+instr_encode_table_t movzx[] = {{ENC_RM, NULL, {0x0F, 0xB7}, {0x0F, 0xB6}, 2, &pre_small_operands, 2}, INSTR_TAB_NULL};
+instr_encode_table_t movsx[] = {{ENC_RM, NULL, {0x0F, 0xBF}, {0x0F, 0xBE}, 2, &pre_small_operands, 2}, INSTR_TAB_NULL};
 
 instr_encode_table_t xchg[] = {
-    {ENC_O, NULL, {0x90}, {NULL}, 1, &same_operand_sizes, false},
-    {ENC_MR, NULL, {0x87}, {0x86}, 1, &same_operand_sizes, true},
-    {ENC_RM, NULL, {0x87}, {0x86}, 1, &same_operand_sizes, true},
+    {ENC_O, NULL, {0x90}, {NULL}, 1, &same_operand_sizes, 0},
+    {ENC_MR, NULL, {0x87}, {0x86}, 1, &same_operand_sizes, 1},
+    {ENC_RM, NULL, {0x87}, {0x86}, 1, &same_operand_sizes, 1},
     INSTR_TAB_NULL,
 };
 
-instr_encode_table_t bswap[] = {{ENC_O, NULL, {0x0F, 0xC8}, {NULL}, 2, &same_operand_sizes, false}, INSTR_TAB_NULL};
+instr_encode_table_t bswap[] = {{ENC_O, NULL, {0x0F, 0xC8}, {NULL}, 2, &same_operand_sizes, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmova[] = {{ENC_RM, NULL, {0x0F, 0x47}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovae[] = {{ENC_RM, NULL, {0x0F, 0x43}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmova[] = {{ENC_RM, NULL, {0x0F, 0x47}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovae[] = {{ENC_RM, NULL, {0x0F, 0x43}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovb[] = {{ENC_RM, NULL, {0x0F, 0x42}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovbe[] = {{ENC_RM, NULL, {0x0F, 0x46}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovb[] = {{ENC_RM, NULL, {0x0F, 0x42}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovbe[] = {{ENC_RM, NULL, {0x0F, 0x46}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmove[] = {{ENC_RM, NULL, {0x0F, 0x44}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmove[] = {{ENC_RM, NULL, {0x0F, 0x44}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovg[] = {{ENC_RM, NULL, {0x0F, 0x4F}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovge[] = {{ENC_RM, NULL, {0x0F, 0x4D}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovg[] = {{ENC_RM, NULL, {0x0F, 0x4F}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovge[] = {{ENC_RM, NULL, {0x0F, 0x4D}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovl[] = {{ENC_RM, NULL, {0x0F, 0x4C}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovle[] = {{ENC_RM, NULL, {0x0F, 0x4E}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovl[] = {{ENC_RM, NULL, {0x0F, 0x4C}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovle[] = {{ENC_RM, NULL, {0x0F, 0x4E}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovna[] = {{ENC_RM, NULL, {0x0F, 0x46}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovnae[] = {{ENC_RM, NULL, {0x0F, 0x42}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovna[] = {{ENC_RM, NULL, {0x0F, 0x46}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovnae[] = {{ENC_RM, NULL, {0x0F, 0x42}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovnb[] = {{ENC_RM, NULL, {0x0F, 0x43}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovnbe[] = {{ENC_RM, NULL, {0x0F, 0x47}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovnb[] = {{ENC_RM, NULL, {0x0F, 0x43}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovnbe[] = {{ENC_RM, NULL, {0x0F, 0x47}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovne[] = {{ENC_RM, NULL, {0x0F, 0x45}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovng[] = {{ENC_RM, NULL, {0x0F, 0x4E}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovnge[] = {{ENC_RM, NULL, {0x0F, 0x4C}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovne[] = {{ENC_RM, NULL, {0x0F, 0x45}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovng[] = {{ENC_RM, NULL, {0x0F, 0x4E}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovnge[] = {{ENC_RM, NULL, {0x0F, 0x4C}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovnl[] = {{ENC_RM, NULL, {0x0F, 0x4D}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovnle[] = {{ENC_RM, NULL, {0x0F, 0x4F}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovnl[] = {{ENC_RM, NULL, {0x0F, 0x4D}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovnle[] = {{ENC_RM, NULL, {0x0F, 0x4F}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovno[] = {{ENC_RM, NULL, {0x0F, 0x41}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovnp[] = {{ENC_RM, NULL, {0x0F, 0x4B}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovno[] = {{ENC_RM, NULL, {0x0F, 0x41}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovnp[] = {{ENC_RM, NULL, {0x0F, 0x4B}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovns[] = {{ENC_RM, NULL, {0x0F, 0x49}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovnz[] = {{ENC_RM, NULL, {0x0F, 0x45}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovns[] = {{ENC_RM, NULL, {0x0F, 0x49}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovnz[] = {{ENC_RM, NULL, {0x0F, 0x45}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovo[] = {{ENC_RM, NULL, {0x0F, 0x40}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovo[] = {{ENC_RM, NULL, {0x0F, 0x40}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovp[] = {{ENC_RM, NULL, {0x0F, 0x4A}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovpe[] = {{ENC_RM, NULL, {0x0F, 0x4A}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
-instr_encode_table_t cmovpo[] = {{ENC_RM, NULL, {0x0F, 0x4B}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovp[] = {{ENC_RM, NULL, {0x0F, 0x4A}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovpe[] = {{ENC_RM, NULL, {0x0F, 0x4A}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
+instr_encode_table_t cmovpo[] = {{ENC_RM, NULL, {0x0F, 0x4B}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovs[] = {{ENC_RM, NULL, {0x0F, 0x48}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovs[] = {{ENC_RM, NULL, {0x0F, 0x48}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};
 
-instr_encode_table_t cmovz[] = {{ENC_RM, NULL, {0x0F, 0x44}, {NULL}, 2, &pre_cmov, false}, INSTR_TAB_NULL};
+instr_encode_table_t cmovz[] = {{ENC_RM, NULL, {0x0F, 0x44}, {NULL}, 2, &pre_cmov, 0}, INSTR_TAB_NULL};


### PR DESCRIPTION
Previously, the `has_byte_opcode` feild has been added to the `instr_encode_table` to show wether a instruction encoder table entry contains a byte opcode (An opcode used **only** when solely byte operands has been supplied). However, some of the instructions have inter-modal opcode sizes, for example the byte opcode can be 2 bytes long and where the standard opcode is only 1 byte long.

Previous efforts of adding a `0x90` to "pad" the opcode was used and retained the same functions of also just simple writing nothing. This pull has omitted this issue by changing the `has_byte_opcode` struct member as a `byte_opcode_size` field to allow it to indicate the pressence of a byte opcode **as well as** a size **at the same time** (Where a `byte_opcode_size` of > 0 and =< 3 means a present byte opcode and shall be encoded by the corrisponding encoder fun- ction)