### PR TITLE
Added text-based instruction table support

### DIFF
--- a/libjas/compile.js
+++ b/libjas/compile.js
@@ -50,4 +50,6 @@ for (const [key, instr] of Object.entries(groups)) {
   output = output.concat(`  INSTR_TAB_NULL,\n};\n`);
 }
 
-console.log(output);
+var prepend = `#include "instr_encode.h" \n#include "pre.c"\n\n`;
+fs.writeFileSync('tabs.c', prepend + output);
+process.exit(0);

--- a/libjas/compile.js
+++ b/libjas/compile.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const file = process.argv[2];
+
+let valid_data = []
+
+fs.readFileSync(file, 'utf8').split('\n').forEach((line) => {
+  let valid_lines = [];
+  if (line[0] === '#') return;
+  if (line === '') return;
+
+  valid_lines.push(line);
+
+  valid_lines.forEach((line) => {
+    line = line.replaceAll(' ', '');
+    let parts = line.split('|');
+    valid_data.push(parts);
+  })
+});
+
+let groups = {};
+
+valid_data.forEach((line) => {
+  if (groups[line[0]] == undefined) groups[line[0]] = [];
+  groups[line[0]].push(line);
+});
+
+function addQuotes(str) { return `{${str}}`; };
+function countComma(input) { return (input.match(/,/g) || []).length; }
+
+let output = "";
+for (const [key, instr] of Object.entries(groups)) {
+  output = output.concat(`instr_encode_table_t ${key.toString()}[] = {\n`)
+  instr.forEach((group) => {
+    const ident = `ENC_${group[1].toUpperCase()}`;
+    if (group[2] === "-") group[2] = "NULL";
+    const ext = group[2];
+    const opcode = addQuotes(group[3]);
+    const opcode_size = countComma(group[3]) + 1;
+    const byte_opcode = addQuotes(group[4]);
+    const byte_opcode_size = countComma(group[4]) + 1;
+    const pre = `&${group[5]}`;
+
+    // Putting it all together
+    output = output.concat(
+        `  {${ident}, ${ext}, ${opcode}, ${byte_opcode}, ${opcode_size}, ${pre}, ${byte_opcode_size}},\n`);
+  });
+
+  output = output.concat(`  INSTR_TAB_NULL,\n};\n`);
+}
+
+console.log(output);

--- a/libjas/instructions.tbl
+++ b/libjas/instructions.tbl
@@ -1,0 +1,27 @@
+# **Notice:** The Jas encoder bank along with the `compiler.js` script
+# is a part of the Jas assembler project, licensed under the MIT license.
+# Please consult the `LICENSE` file for more information.
+
+# Contributors' list: (Add your own name here, if applicable)
+# Copyright (c) 2023-2024 Alvin Cheng <eventide1029@gmail.com>
+
+# This is the Jas assembler instruction encoder bank, this file contains
+# the encoder tables for encoding the instructions into machine code, with
+# each one handcrafted and reviewed by actual humans, not a dumb script that
+# runs through the Intel Manual. 
+
+# This is basically, (when boiled down) a successor to the `tabs.c` file as a 
+# representation of structs by allowing a script to write boilerplate for us.
+# All columns are matching the values of the `instr_encode_table` struct, see
+# `instruction.h` for more information. (Data sizes and omitted fields are auto-
+# matically computed by the compiler script)
+
+
+
+
+# name | identity | opcode extension | opcode            | byte opcode       | pre 
+# -----------------------------------------------------------------------------------------------
+  mov  | mr       | -                | 0x89              | 0x88              | same_operand_sizes
+  mov  | rm       | -                | 0x8B              | 0x8A              | same_operand_sizes
+  mov  | oi       | -                | 0xB8              | 0xB0              | same_operand_sizes
+  mov  | mi       | 0b10000000       | 0xC7              | 0xC6              | pre_imm 


### PR DESCRIPTION
Previously and also as of the current codebase, everything (all the instruction enocder tables) have been represented in C and in a huge file of structs. (Not very maintainable or readable, frankly) This pull has added a compiler for a text-based format (`.tbl` files which the linux kernel also uses for kernel-system-calls).

In a nutshell, the `.tbl` file has options consisting of the corrisponding values in a equivilent C structure such as opcode, opcode extention and pre functions, with some changed. These values will be read and parsed, then produced into a C syntax to be fed into the compiler as C code. (For more information, please see the `instruction.tbl` file's comments)