### PR TITLE
Changes to instruction encoder bank compiler scripts

### DIFF
--- a/libjas/compile.js
+++ b/libjas/compile.js
@@ -38,9 +38,14 @@ for (const [key, instr] of Object.entries(groups)) {
     const ext = group[2];
     const opcode = addQuotes(group[3]);
     const opcode_size = countComma(group[3]) + 1;
-    const byte_opcode = addQuotes(group[4]);
+    const byte_opcode = group[4] == "-" ? "NULL" : addQuotes(group[4]);
     const byte_opcode_size = countComma(group[4]) + 1;
-    const pre = `&${group[5]}`;
+
+    let pre;
+    if (group[5] == "-")
+      pre = "NULL";
+    else
+      pre = `&${group[5]}`;
 
     // Putting it all together
     output = output.concat(
@@ -50,6 +55,6 @@ for (const [key, instr] of Object.entries(groups)) {
   output = output.concat(`  INSTR_TAB_NULL,\n};\n`);
 }
 
-var prepend = `#include "instr_encode.h" \n#include "pre.c"\n\n`;
+var prepend = `#include "instruction.h" \n#include "pre.c"\n\n`;
 fs.writeFileSync('tabs.c', prepend + output);
 process.exit(0);

--- a/libjas/tablegen.js
+++ b/libjas/tablegen.js
@@ -13,7 +13,7 @@ const byte_opcode = process.argv[6];
 const pre = process.argv[7];
 
 let out = ""
-out = out.concat(`  ${name}  |`);
+out = out.concat(`  ${name}${" ".repeat(5 - name.length)}|`);
 out = out.concat(` ${ident}${" ".repeat(9 - ident.length)}|`);
 out = out.concat(` ${opcode_ext}${" ".repeat(17 - opcode_ext.length)}|`);
 out = out.concat(` ${opcode}${" ".repeat(18 - opcode.length)}|`);


### PR DESCRIPTION
This pull solves and patches some formatting issues regarding the automatic generation of the instruction table; as well as the syntax errors when compiling it to the native C struct representation.