### PR TITLE
Minor script changes

### DIFF
--- a/libjas/compile.js
+++ b/libjas/compile.js
@@ -38,8 +38,9 @@ for (const [key, instr] of Object.entries(groups)) {
     const ext = group[2];
     const opcode = addQuotes(group[3]);
     const opcode_size = countComma(group[3]) + 1;
-    const byte_opcode = group[4] == "-" ? "NULL" : addQuotes(group[4]);
-    const byte_opcode_size = countComma(group[4]) + 1;
+    const byte_opcode = addQuotes(group[4] == "-" ? "NULL" : group[4]);
+    let byte_opcode_size = countComma(group[4]) + 1;
+    if (group[4] == "-") byte_opcode_size = 0;
 
     let pre;
     if (group[5] == "-")

--- a/libjas/tablegen.js
+++ b/libjas/tablegen.js
@@ -3,17 +3,29 @@
 // Usage: node tablegen.js <name> <ident> <opcode_ext> <opcode> <byte_opcode> <pre>
 // And you can use `>>` to append to a file, usually for the instructions.tbl file.
 
+// Note: if argv[3] zo, just type n an opcode and everything will fall into place automatically.
+
 const process = require('process');
 
-const name = process.argv[2];
-const ident = process.argv[3];
-const opcode_ext = process.argv[4];
-const opcode = process.argv[5];
-const byte_opcode = process.argv[6];
-const pre = process.argv[7];
+let name = process.argv[2];
+let ident = process.argv[3];
+let opcode_ext = process.argv[4];
+let opcode = process.argv[5];
+let byte_opcode = process.argv[6];
+let pre = process.argv[7];
+
+if (process.argv[3] == 'zo') {
+  opcode = process.argv[4];
+  byte_opcode = "-";
+  pre = "no_operands";
+  opcode_ext = "-";
+}
 
 let out = ""
-out = out.concat(`  ${name}${" ".repeat(5 - name.length)}|`);
+let len = 5 - name.length
+if (len < 0) len = 1;
+
+out = out.concat(`  ${name}${" ".repeat(len)}|`);
 out = out.concat(` ${ident}${" ".repeat(9 - ident.length)}|`);
 out = out.concat(` ${opcode_ext}${" ".repeat(17 - opcode_ext.length)}|`);
 out = out.concat(` ${opcode}${" ".repeat(18 - opcode.length)}|`);


### PR DESCRIPTION
In the compiler script for the text-based instruction enocder bank,
the C compiler has encountered issues where when the array was gen-
erated as `NULL` pruely, it reconised the following elements as the
*members* of the array rather than sibling elements *inside the object*.
The exclusion of quotes in the empty array has also lead to the
throwing of the error: "Invalid integer conversion resulting from
truncation", which supports the relavant assumption that the struct
members has been parsed as array members instead.

Also, a guard clause has also been added to check if the grouping of
the byte opcode, writing in `0` as the byte opcode size if its set as
`NULL`. Previously the compiler has mis-read it has `1` since it counted
the number of commas, defaulting to `1` as the default opcode size.
This worked in the *normal opcode* where it was required but did not
work as intended when put into use in the byte opcode field.