### PR TITLE
Dereferenced the pointer to free the correct pointer

### DIFF
--- a/libjas/label.c
+++ b/libjas/label.c
@@ -54,7 +54,7 @@ void label_create(
 }
 
 void label_destroy_all(label_t **label_table, size_t *label_table_size) {
-  free(label_table);
+  free(*label_table);
 
   label_table = NULL;
   *(label_table_size) = 0;


### PR DESCRIPTION
In the `label_free()` function, the function attempted to call `free` on the basis of the pointer to the allocated memory, rather than the actually memory that had to be freed. Ultimately, causing the program to throw a *"pointer freed has not been allocated"* error during run- time. This issue arose since I have attempted to use the pointer of a pointer to the allocated data to allow the pointer to updated by ref- erence, making it more seemless. But, this ended in tradgity lol.