### PR TITLE
Encoder bank fixes

### DIFF
--- a/libjas/Makefile
+++ b/libjas/Makefile
@@ -16,7 +16,6 @@ libjas_debug.a: $(OBJ)
 
 tabs.c: instructions.tbl
 	node compile.js $^ 
-	clang-format $@ -i
 
 # Individual object files rules:
 operand_cpp.o: CFLAGS = $(CFLAGS_COMMON) -std=c++11 -O0

--- a/libjas/Makefile
+++ b/libjas/Makefile
@@ -7,13 +7,14 @@ C_SRC = $(wildcard *.c) # Includes only C source files
 OBJ = $(patsubst %.c, %.o, $(C_SRC)) operand_cpp.o 
 BUILD = ../build
 
-libjas.a: tabs.c
 libjas.a: $(OBJ) 
+	$(MAKE) tabs.c
 	ar rcs $(BUILD)/$@ $^ 
 
 libjas_debug.a: CFLAGS = $(CFLAGS_COMMON) -g -std=c99 -O0
 libjas_debug.a: tabs.c
 libjas_debug.a: $(OBJ)
+	$(MAKE) tabs.c
 	ar rcs $(BUILD)/$@ $^
 
 tabs.c: instructions.tbl

--- a/libjas/Makefile
+++ b/libjas/Makefile
@@ -7,10 +7,12 @@ C_SRC = $(wildcard *.c) # Includes only C source files
 OBJ = $(patsubst %.c, %.o, $(C_SRC)) operand_cpp.o 
 BUILD = ../build
 
+libjas.a: tabs.c
 libjas.a: $(OBJ) 
 	ar rcs $(BUILD)/$@ $^ 
 
 libjas_debug.a: CFLAGS = $(CFLAGS_COMMON) -g -std=c99 -O0
+libjas_debug.a: tabs.c
 libjas_debug.a: $(OBJ)
 	ar rcs $(BUILD)/$@ $^
 

--- a/libjas/instructions.tbl
+++ b/libjas/instructions.tbl
@@ -106,7 +106,7 @@
   xchg | rm       | -                | 0x87              | 0x86              | same_operand_sizes
 
 # --------------------------------------------------------------------------------------------------
-  syscall | zo       | -                | 0x0f              | -                 | no_operands
+  syscall | zo       | -                | 0x0f, 0x05         | -                 | no_operands
   movzx   | rm       | -                | 0x0F, 0xB7        | 0x0F, 0xB6        | pre_small_operands
   movsx   | rm       | -                | 0x0F, 0xBF        | 0x0F, 0xBE        | pre_small_operands  
   bswap   | o        | -                | 0x0f, 0xC8        | -                 | same_operand_sizes

--- a/libjas/instructions.tbl
+++ b/libjas/instructions.tbl
@@ -33,7 +33,7 @@
   sub  | rm       | -                | 0x2b              | 0x2a              | same_operand_sizes
   sub  | mr       | -                | 0x29              | 0x28              | same_operand_sizes
   sub  | i        | -                | 0x2c              | 0x2d              | pre_imm
-  sub  | mi       | 8                | 0x80              | 0x81              | pre_imm
+  sub  | mi       | 5                | 0x81              | 0x80              | pre_imm
 
   mul  | m        | 4                | 0xF7              | 0xF6              | - 
 


### PR DESCRIPTION
Some fixes regarding mis-read or mistaken encoder bank values such as encoder operands and/or opcodes. Mostly **human-errors** no signs of issues on the `compile.js` or `tablegen.js` scripts.