### PR TITLE
Carried out refactoring for `operand.c`'s module

### DIFF
--- a/libjas/include/operand.h
+++ b/libjas/include/operand.h
@@ -177,23 +177,6 @@ uint8_t op_modrm_mode(operand_t input);
 uint8_t op_sizeof(enum operands input);
 
 /**
- * Function for constructing an operand struct with the given
- * type, offset and data. Therefore, prevents the temptation
- * to make things difficult by using the struct initializer
- * as well as mangling around with void pointers.
- *
- * @param type The type of the operand
- * @param offset The offset of the operand
- * @param data The data of the operand
- * @param label The name of the referenced label (if applicable)
- * @return The constructed operand struct
- *
- * @note Operands and parameter types are based on `operand_t`
- * @see `operand_t`
- */
-operand_t op_construct_operand(enum operands type, size_t offset, void *data, char *label);
-
-/**
  * Function for returning the opcode of the instruction based
  * on the instruction encoder table provided in the function
  * arguments as well as if a byte opcode is provided in the

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -99,7 +99,7 @@ instruction_t *instr_gen(enum instructions instr, uint8_t operand_count, ...) {
       const size_t label_name_size = strlen(lab) + 1;
       char *copied_name = malloc(label_name_size);
       strcpy(copied_name, lab);
-      
+
       label = copied_name;
 
       // clang-format off
@@ -118,7 +118,8 @@ instruction_t *instr_gen(enum instructions instr, uint8_t operand_count, ...) {
       alloc_operand_data(temp_reg); /* Note braces as macro expands */
     }
     const size_t off = va_arg(args, size_t);
-    operands[i] = op_construct_operand(type, off, data, label);
+    operands[i] =
+        (operand_t){.type = type, .offset = off, .data = data, .label = label};
   }
 
   va_end(args);
@@ -146,7 +147,13 @@ instruction_t *instr_write_bytes(size_t data_sz, ...) {
   memcpy(buffer_ptr, &data, sizeof(buffer_t));
 
   operand_t *operands = calloc(4, sizeof(operand_t));
-  operands[0] = op_construct_operand(OP_MISC, 0, buffer_ptr, NULL);
+  operands[0] =
+      (operand_t){
+          .type = (enum operands)OP_MISC,
+          .offset = 0,
+          .data = buffer_ptr,
+          .label = NULL,
+      };
 
   *instr_ret = (instruction_t){
       .instr = INSTR_DIR_WRT_BUF,


### PR DESCRIPTION
This pull has completed several refactoring works conducted for the `operand.c` file, as shown below, please consult the patch file for a more detailed changelog, take this as a TL;DR or a justification:

- Removed `op_construct_operand` function This pull has seen the removal of the `op_construct_operand` function, this function has been of no (or little) use of the assembler and has been sitting as a pile of junk, taking up space and building complexity in the codebase where the objectives could've been acheived using a simpel object-literal (Albeit a bit unpleasing to our eyeballs)

- Modified/omitted error messages (Will soon be done to whole codebase) This pull has also changed certain error messages for the sake on consistency among other command line tools. Most command line tools do not usually start their messages with a uppercase, rather is appended based off a previous prefix. Furthermore, some are just simply too long and takes up an unreasonable space in memory and stretches out like a noodle.

- Removed and modified comments Some comments have been removed due to its vague or non-existant purpose. A previous explaination for the `operand_write_prefix` function has been moved further down the file to prevent disturbance of the code.