### PR TITLE
Removed the `pre_in_out`

### DIFF
--- a/libjas/instructions.tbl
+++ b/libjas/instructions.tbl
@@ -99,7 +99,7 @@
   sti  | zo       | -                | 0xFB              | -                 | -
   nop  | zo       | -                | 0x90              | -                 | -
   hlt  | zo       | -                | 0xF4              | -                 | -
-  _int | i        | -                | 0xCD              | -                 | pre_int
+  _int | i        | -                | -                 | 0xCD              | -
 
   xchg | o        | -                | 0x90              | -                 | -
   xchg | mr       | -                | 0x87              | 0x86              | -

--- a/libjas/instructions.tbl
+++ b/libjas/instructions.tbl
@@ -75,7 +75,7 @@
   call | m        | 2                | 0xFF              | -                 | -
 
   ret  | zo       | -                | 0xC3              | -                 | -
-  ret  | i        | -                | 0xC2              | -                 | pre_ret
+  ret  | i        | -                | 0xC2              | -                 | -
 
   cmp  | rm       | -                | 0x3B              | 0x3A              | -
   cmp  | mr       | -                | 0x39              | 0x38              | -
@@ -89,11 +89,9 @@
   pop  | m        | 0                | 0x8F              | -                 | -
   pop  | o        | -                | 0x58              | -                 | -
 
-  in   | oi       | -                | 0xE5              | 0xE4              | pre_in_out
-  in   | -        | -                | 0xED              | 0xEC              | pre_in_out
+  in   | oi       | -                | -                 | 0xE4              | -
 
-  out  | -        | -                | 0xEF              | 0xEE              | pre_in_out
-  out  | oi       | -                | 0xE7              | 0xE6              | pre_in_out
+  out  | oi       | -                | -                 | 0xE6              | -
 
   clc  | zo       | -                | 0xF8              | -                 | -
   stc  | zo       | -                | 0xF9              | -                 | -

--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -66,17 +66,19 @@ uint8_t op_sizeof(enum operands input) {
 }
 
 uint8_t *op_write_opcode(operand_t *op_arr, instr_encode_table_t *instr_ref) {
-  if (instr_ref->byte_opcode_size > 0) return instr_ref->opcode;
-
   for (uint8_t i = 0; i < 4; i++) {
     if (op_arr[i].type == OP_NULL) break;
     if (op_byte(op_arr[i].type)) {
-      if (!instr_ref->byte_instr_opcode) err("invalid operands");
+      if (instr_ref->byte_opcode_size == 0) goto op_e;
       return instr_ref->byte_instr_opcode;
     }
   }
-
+  if (!instr_ref->opcode_size) goto op_e;
   return instr_ref->opcode;
+
+op_e:
+  err("operand type mismatch");
+  return NULL;
 }
 
 void op_write_prefix(buffer_t *buf, const operand_t *op_arr, enum modes mode) {

--- a/libjas/pre.c
+++ b/libjas/pre.c
@@ -27,12 +27,3 @@ DEFINE_PRE_ENCODER(pre_small_operands) {
   if (op_sizeof(op_arr[1].type) < 16)
     err("Invalid operand size for MOVZX/MOVSX instruction");
 }
-
-DEFINE_PRE_ENCODER(pre_in_out) {
-  const enum registers reg = *(enum registers *)op_arr[0].data;
-  if (reg != REG_AL && reg != REG_AX && reg != REG_EAX)
-    err("Invalid operand for IN/OUT instruction.");
-
-  if (op_sizeof(op_arr[1].type) > 16 && *(enum registers *)op_arr[1].data != REG_DX)
-    err("Byte or `dx` operands needs to be used with the IN/OUT instruction.");
-}

--- a/libjas/pre.c
+++ b/libjas/pre.c
@@ -18,11 +18,6 @@ DEFINE_PRE_ENCODER(pre_ret) {
     err("Other operand sizes cannot be used with this instruction.");
 }
 
-DEFINE_PRE_ENCODER(pre_int) {
-  if (op_sizeof(op_arr[0].type) != 8)
-    err("Invalid operand size for INT instruction.");
-}
-
 DEFINE_PRE_ENCODER(pre_small_operands) {
   if (op_sizeof(op_arr[1].type) < 16)
     err("Invalid operand size for MOVZX/MOVSX instruction");

--- a/libjas/scripts/compile.js
+++ b/libjas/scripts/compile.js
@@ -39,7 +39,7 @@ for (const [key, instr] of Object.entries(groups)) {
     const ident = `ENC_${group[1].toUpperCase()}`;
     if (group[2] === "-") group[2] = "NULL";
     const ext = group[2];
-    const opcode = addQuotes(group[3]);
+    const opcode = addQuotes(group[3] == "-" ? "NULL" : group[3]);
     const opcode_size = countComma(group[3]) + 1;
     const byte_opcode = addQuotes(group[4] == "-" ? "NULL" : group[4]);
     let byte_opcode_size = countComma(group[4]) + 1;


### PR DESCRIPTION
This pull has removed the `pre_in_out` pre-processor applicable for the `in` and `out` instructions. In particular, these instructions does not allow the use of operands other than 8-bit operands, this pull has modified the `op_write_opcode` to allow the function to catch certain in consistencies which may violate these rules. Instructions which use this behavior should leave the "normal" opcode empty, only providing the `byte_instr_opcode`.