### PR TITLE
Buffer instruction generic migration

### DIFF
--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -132,7 +132,14 @@ extern instr_encode_table_t *instr_table[];
 typedef struct instr_generic {
   enum { INSTR, DIRECTIVE } type; /* Type of assembler input */
 
-  // Union - Document later
+  /** 
+   * Two forms of inputs are accepted into the Jas assembler, an 
+   * instruction and directive. Directives are used to alter the 
+   * basic behavior of the assembler and its compilation steps.
+   * 
+   * The union shares memory with both functionality, allowing
+   * both types of data to be read through a single structure.
+   */
   union {
     struct instruction instr;
     struct instr_directive dir;

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -198,15 +198,9 @@ instr_encode_table_t instr_get_tab(instruction_t instr);
  * @param data_sz The size of the data to write
  * @param ... The data to write into the buffer
  *
- * @return The instruction struct pointer
- *
- * @example The **Jas** function call of:
- * >  instr_write_bytes(7, 0x48, 0x89, 0x80, 0xff, 0x00, 0x00, 0x00);
- *
- * Is equivalent to: (In NASM)
- * >  db 0x48, 0x89, 0x80, 0xff, 0x00, 0x00, 0x00
+ * @return The instruction generic pointer
  */
-instruction_t *instr_write_bytes(size_t data_sz, ...);
+instr_generic_t *instr_write_bytes(size_t data_sz, ...);
 
 /**
  * Macros for defining the instruction operands in a more readable

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -162,7 +162,7 @@ typedef struct instr_generic {
     struct instruction instr;
     struct instr_directive dir;
   };
-};
+} instr_generic_t;
 
 #define INSTR_TAB_NULL           \
   (instr_encode_table_t) {       \

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -35,11 +35,8 @@ typedef struct instr_encode_table instr_encode_table_t;
 
 enum instr_directives {
   DIR_DEFINE_BYTES,
-
-  DIR_LOCAL_LABEL,
-  DIR_GLOBAL_LABEL,
-  DIR_EXTERN_LABEL,
-}
+  DIR_DEFINE_LABEL,
+};
 
 enum instructions {
   INSTR_NULL,
@@ -129,14 +126,35 @@ struct instr_encode_table {
  */
 extern instr_encode_table_t *instr_table[];
 
-typedef struct instr_generic {
-  enum { INSTR, DIRECTIVE } type; /* Type of assembler input */
+typedef struct instruction {
+  enum instructions instr; /* Type of instruction */
+  operand_t *operands;     /* Operands of the instruction */
+} instruction_t;
 
-  /** 
-   * Two forms of inputs are accepted into the Jas assembler, an 
-   * instruction and directive. Directives are used to alter the 
+typedef struct instr_directive {
+  enum instr_directives dir; /* Type of directive */
+
+  /**
+   * Payload data of the directive may vary depending on the type
+   * of directive. For example, the `DIR_DEFINE_BYTES` directive
+   * will have a data payload that contains the bytes to define
+   * in a `buffer_t`format.
+   */
+  union {
+    label_t label; /* Label portion of directive */
+    buffer_t data; /* Data portion of directive */
+  };
+} instr_directive_t;
+
+typedef struct instr_generic {
+  enum { INSTR,
+         DIRECTIVE } type; /* Type of assembler input */
+
+  /**
+   * Two forms of inputs are accepted into the Jas assembler, an
+   * instruction and directive. Directives are used to alter the
    * basic behavior of the assembler and its compilation steps.
-   * 
+   *
    * The union shares memory with both functionality, allowing
    * both types of data to be read through a single structure.
    */
@@ -144,12 +162,7 @@ typedef struct instr_generic {
     struct instruction instr;
     struct instr_directive dir;
   };
-}
-
-typedef struct instruction {
-  enum instructions instr; /* Type of instruction */
-  operand_t *operands;     /* Operands of the instruction */
-} instruction_t;
+};
 
 #define INSTR_TAB_NULL           \
   (instr_encode_table_t) {       \

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -49,7 +49,7 @@ instr_encode_table_t *instr_table[] =
 #define CURR_TABLE instr_table[instr.instr][j]
 
 instr_encode_table_t instr_get_tab(instruction_t instr) {
-  if (instr.instr == INSTR_NOTHING && instr.operands == NULL) return INSTR_TAB_NULL;
+  if (instr.instr == INSTR_NULL && instr.operands == NULL) return INSTR_TAB_NULL;
   if (INSTR_DIRECTIVE(instr.instr)) return INSTR_TAB_NULL; // aka empty
   const enum operands operand_list[4] = {
       instr.operands[0].type, instr.operands[1].type,
@@ -155,6 +155,7 @@ instruction_t *instr_write_bytes(size_t data_sz, ...) {
           .label = NULL,
       };
 
+  // TODO for directives
   *instr_ret = (instruction_t){
       .instr = INSTR_DIR_WRT_BUF,
       .operands = operands,

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -129,8 +129,7 @@ instruction_t *instr_gen(enum instructions instr, uint8_t operand_count, ...) {
 }
 #undef alloc_data
 
-// TODO Migrate to `instr_generic` type interface
-instruction_t *instr_write_bytes(size_t data_sz, ...) {
+instr_generic_t *instr_write_bytes(size_t data_sz, ...) {
   buffer_t *buffer_ptr = malloc(sizeof(buffer_t));
   buffer_t data = BUF_NULL;
   va_list args;
@@ -143,26 +142,20 @@ instruction_t *instr_write_bytes(size_t data_sz, ...) {
 
   va_end(args);
 
-  instruction_t *instr_ret = malloc(sizeof(instruction_t));
-  memcpy(buffer_ptr, &data, sizeof(buffer_t));
+  instr_generic_t *instr_ret = malloc(sizeof(instr_generic_t));
 
-  operand_t *operands = calloc(4, sizeof(operand_t));
-  operands[0] =
-      (operand_t){
-          .type = (enum operands)OP_MISC,
-          .offset = 0,
-          .data = buffer_ptr,
-          .label = NULL,
-      };
-
-  // TODO for directives
-  *instr_ret = (instruction_t){
-      .instr = INSTR_DIR_WRT_BUF,
-      .operands = operands,
+  *instr_ret = (instr_generic_t){
+      .type = DIRECTIVE,
+      .dir = (instr_directive_t){
+          .dir = DIR_DEFINE_BYTES,
+          .data = data,
+      },
   };
-
   return instr_ret;
 }
+
+// Please note: from this point, **every** generic instruction
+// is to be allocated.
 
 void instr_free(instruction_t *instr) {
   for (uint8_t i = 0; i < 4; i++) {

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -76,7 +76,6 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
     data = (void *)type##_;                  \
   } while (0);
 
-/* Stupid almost-stub implementation */
 instruction_t *instr_gen(enum instructions instr, uint8_t operand_count, ...) {
   va_list args;
   va_start(args, operand_count * 3);
@@ -130,6 +129,7 @@ instruction_t *instr_gen(enum instructions instr, uint8_t operand_count, ...) {
 }
 #undef alloc_data
 
+// TODO Migrate to `instr_generic` type interface
 instruction_t *instr_write_bytes(size_t data_sz, ...) {
   buffer_t *buffer_ptr = malloc(sizeof(buffer_t));
   buffer_t data = BUF_NULL;


### PR DESCRIPTION
This pull has migrated over the `instr_write_bytes` function to return a `instr_generic_t` output, rather than the vague, old `instruction_t` struct since the changes presented within #95. #95 provided a good starting point for allowing for the easier input for the assembler and more additional details may be presented within.

This pull request would be pulled into the #95 branch to preserve all commit history.