### PR TITLE
Completed migration of `instr_free`

### DIFF
--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -289,12 +289,12 @@ instruction_t *instr_gen(enum instructions instr, uint8_t operand_count, ...);
  * leaks and free the memory allocated for the instruction structs
  * and the operand structs that are nested inside the instruction.
  *
- * @param instr The instruction struct to free
+ * @param instr The instruction generic struct to free
  *
  * @note This function should only be used to free instruction allocated
  * using built-in Jas instruction generation functions, unless you actually
  * know what you are doing.
  */
-void instr_free(instruction_t *instr);
+void instr_free(instr_generic_t *instr);
 
 #endif

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -69,6 +69,36 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
 }
 #undef CURR_TABLE
 
+static void __instr_free__(instruction_t *instr) {
+  for (uint8_t i = 0; i < 4; i++) {
+    if (instr->operands[i].type == OP_NULL) break;
+    if (instr->operands[i].type) free(instr->operands[i].data);
+  }
+
+  free(instr->operands);
+  free(instr);
+}
+
+void instr_free(instr_generic_t *instr) {
+  if (instr->type == INSTR) __instr_free__(&(instr->instr));
+
+  if (instr->type == DIRECTIVE) {
+    if (instr->dir.dir == DIR_DEFINE_LABEL) {
+      if (strlen(instr->dir.label.name)) {
+        const char *label_name = instr->dir.label.name;
+        free(label_name);
+      }
+    }
+
+    if (instr->dir.dir == DIR_DEFINE_BYTES) {
+      const uint8_t buffer = instr->dir.data.data;
+      free(buffer);
+    }
+  }
+
+  free(instr); // All done now.
+}
+
 #define alloc_operand_data(type)             \
   do {                                       \
     type *type##_ = malloc(sizeof(type));    \
@@ -152,27 +182,4 @@ instr_generic_t *instr_write_bytes(size_t data_sz, ...) {
       },
   };
   return instr_ret;
-}
-
-// Please note: from this point, **every** generic instruction
-// is to be allocated.
-
-void instr_free(instruction_t *instr) {
-  for (uint8_t i = 0; i < 4; i++) {
-    if (instr->operands[i].type == OP_NULL) break;
-    if (instr->operands[i].type == OP_MISC && instr->instr == INSTR_DIR_WRT_BUF) {
-      buffer_t *data = (buffer_t *)instr->operands[i].data;
-      free(data->data);
-    }
-
-    if (strlen(instr->operands[i].label)) {
-      free(instr->operands[i].label);
-      continue;
-    }
-
-    if (instr->operands[i].type) free(instr->operands[i].data);
-  }
-
-  free(instr->operands);
-  free(instr);
 }


### PR DESCRIPTION
This pull has completed the migration of the `instr_free` function as the funciton solely in the dealings of the `instr_generic_t` struct. Previously, this funciton dealt with the old `instruction_t` structures. The `instr_free` function also failed to account for new directive organisations among other things. (Which has been since patched through this patch)

Despite the migration of the `instr_free` function, work still needs to be completed for the `instr_gen` countrerpart to catchup in the same utilisation of the new `instr_generic_t` organisation framework.