### PR TITLE
Migrated label creation function

### DIFF
--- a/libjas/include/label.h
+++ b/libjas/include/label.h
@@ -98,20 +98,16 @@ enum label_type {
 };
 
 /**
- * Function similar to `instr_ge()` and `label_create()`, used to
- * generate a label instruction in the instruction array, and
- * return the instruction struct back to the caller.
+ * Function for generating an instruction generic structure for the
+ * represented label, with relative ease of use. This function would
+ * automatically create the instruction generic, leading to an instr-
+ * uction directive.
  *
- * @param name The name of the label to be generated.
- * @param type The type of the label. @see `enum label_type`
+ * @param name Name of the label to be created.
+ * @param type The permissions of this label, as defined in the OS.
  *
- * @return The instruction struct pointer of the label generated.
- *
- * @note The label name should not contain the `:` character, as
- * it is automatically added by the assembler. (The `:` character
- * is a label terminator usually found in assembly languages, and
- * does not get used in this assembler, typing in `:` would result
- * in that carrying over to the output)
+ * @return The instruction generic pointer: @note should be freed
  */
-instruction_t *label_gen(char *name, enum label_type type);
+instr_generic_t *label_gen(char *name, enum label_type type);
+
 #endif

--- a/libjas/label.c
+++ b/libjas/label.c
@@ -70,14 +70,14 @@ label_t *label_lookup(label_t **label_table, size_t *label_table_size, char *nam
   return NULL;
 }
 
-instruction_t *label_gen(char *name, enum label_type type) {
-  enum instructions instr = INSTR_DIR_LOCAL_LABEL;
+instr_generic_t *label_gen(char *name, enum label_type type) {
+  label_t label_instance;
 
   // clang-format off
   switch (type) {
-    case LABEL_LOCAL: instr = INSTR_DIR_LOCAL_LABEL; break;
-    case LABEL_GLOBAL: instr = INSTR_DIR_GLOBAL_LABEL; break;
-    case LABEL_EXTERN: instr = INSTR_DIR_EXTERN_LABEL; break;
+    case LABEL_LOCAL: break;
+    case LABEL_GLOBAL: label_instance.exported = true; break;
+    case LABEL_EXTERN: label_instance.ext = true; break;
 
     default: break;
   }
@@ -85,21 +85,16 @@ instruction_t *label_gen(char *name, enum label_type type) {
 
   const size_t label_name_size = strlen(name) + 1;
   char *copied_name = malloc(label_name_size);
-  strcpy(copied_name, name);
+  strcpy(copied_name, label_instance.name);
 
-  operand_t *operands = calloc(4, sizeof(operand_t));
-  operands[0] =
-      (operand_t){
-          .type = OP_MISC,
-          .offset = 0,
-          .data = copied_name,
-          .label = NULL,
-      };
+  instr_generic_t *instr_ret = malloc(sizeof(instr_generic_t));
 
-  instruction_t *instr_ret = malloc(sizeof(instruction_t));
-  *instr_ret = (instruction_t){
-      .instr = instr,
-      .operands = operands,
+  *instr_ret = (instr_generic_t){
+      .type = DIRECTIVE,
+      .dir = (instr_directive_t){
+          .dir = DIR_DEFINE_LABEL,
+          .label = label_instance,
+      },
   };
 
   return instr_ret;


### PR DESCRIPTION
This commit & pull has finished the migration of the `label_gen` funciton from the old `instruction_t`. This funciton also previously used the old framework of the instruciton organisation, which we have since corrected for.

Now, the name and scope of the label can be provided using the revised `label_gen` function and a new instruciton generic structure would be produced to be passed into the `codegen` functon along with other instructions. Ultimately, when all works has been completed, this would finally allow for the sreamlining of the assembler's inputs and controls (in the form of directives)