### PR TITLE
Moved directives to its own isolated file of `dir.h`

### DIFF
--- a/libjas/include/dir.h
+++ b/libjas/include/dir.h
@@ -43,6 +43,11 @@ typedef struct directive {
   union {
     label_t label; /* Label portion of directive */
     buffer_t data; /* Data portion of directive */
+
+    /// @brief To be used for future directives where applicable
+    /// with miscellaneous data such as alignment, etc.
+
+    void *misc; /* Miscellaneous data portion of directive */
   };
 } directive_t;
 

--- a/libjas/include/dir.h
+++ b/libjas/include/dir.h
@@ -1,0 +1,49 @@
+/**
+ * MIT License
+ * Copyright (c) 2023-2024 Alvin Cheng <eventide1029@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * @see `LICENSE`
+ */
+
+#ifndef DIR_H
+#define DIR_H
+
+enum directives {
+  DIR_DEFINE_BYTES,
+  DIR_DEFINE_LABEL,
+};
+
+typedef struct directive {
+  enum directives dir; /* Type of directive */
+
+  /**
+   * Payload data of the directive may vary depending on the type
+   * of directive. For example, the `DIR_DEFINE_BYTES` directive
+   * will have a data payload that contains the bytes to define
+   * in a `buffer_t`format.
+   */
+  union {
+    label_t label; /* Label portion of directive */
+    buffer_t data; /* Data portion of directive */
+  };
+} directive_t;
+
+#endif

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -33,10 +33,7 @@
 // Forward declaration - see instr_encode_table
 typedef struct instr_encode_table instr_encode_table_t;
 
-enum instr_directives {
-  DIR_DEFINE_BYTES,
-  DIR_DEFINE_LABEL,
-};
+#include "dir.h"
 
 enum instructions {
   INSTR_NULL,
@@ -131,21 +128,6 @@ typedef struct instruction {
   operand_t *operands;     /* Operands of the instruction */
 } instruction_t;
 
-typedef struct instr_directive {
-  enum instr_directives dir; /* Type of directive */
-
-  /**
-   * Payload data of the directive may vary depending on the type
-   * of directive. For example, the `DIR_DEFINE_BYTES` directive
-   * will have a data payload that contains the bytes to define
-   * in a `buffer_t`format.
-   */
-  union {
-    label_t label; /* Label portion of directive */
-    buffer_t data; /* Data portion of directive */
-  };
-} instr_directive_t;
-
 typedef struct instr_generic {
   enum { INSTR,
          DIRECTIVE } type; /* Type of assembler input */
@@ -160,7 +142,7 @@ typedef struct instr_generic {
    */
   union {
     struct instruction instr;
-    struct instr_directive dir;
+    struct directive dir;
   };
 } instr_generic_t;
 
@@ -259,7 +241,7 @@ instr_generic_t *instr_write_bytes(size_t data_sz, ...);
  * @return The instruction struct pointer
  *
  * @note This function returns a pointer to a dynamically allocated generic
- * struct, not a default instruction struct. Extract the pure instruction 
+ * struct, not a default instruction struct. Extract the pure instruction
  * through the `instr` property.
  */
 instr_generic_t *instr_gen(enum instructions instr, uint8_t operand_count, ...);

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -24,6 +24,7 @@
  */
 
 #include "instruction.h"
+#include "dir.h"
 #include "error.h"
 #include "register.h"
 #include "tabs.c"

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -147,7 +147,7 @@ instr_generic_t *instr_gen(enum instructions instr, uint8_t operand_count, ...) 
       alloc_operand_data(temp_reg); /* Note braces as macro expands */
     }
     const size_t off = va_arg(args, size_t);
-    operands[i] = (operand_t){ data, type, off, label };
+    operands[i] = (operand_t){data, type, off, label};
   }
 
   va_end(args);
@@ -180,7 +180,7 @@ instr_generic_t *instr_write_bytes(size_t data_sz, ...) {
 
   *instr_ret = (instr_generic_t){
       .type = DIRECTIVE,
-      .dir = (instr_directive_t){
+      .dir = (directive_t){
           .dir = DIR_DEFINE_BYTES,
           .data = data,
       },

--- a/libjas/label.c
+++ b/libjas/label.c
@@ -91,7 +91,7 @@ instr_generic_t *label_gen(char *name, enum label_type type) {
 
   *instr_ret = (instr_generic_t){
       .type = DIRECTIVE,
-      .dir = (instr_directive_t){
+      .dir = (directive_t){
           .dir = DIR_DEFINE_LABEL,
           .label = label_instance,
       },

--- a/libjas/label.c
+++ b/libjas/label.c
@@ -25,6 +25,7 @@
 
 #include "label.h"
 #include "codegen.h"
+#include "dir.h"
 #include "error.h"
 #include "operand.h"
 #include <stdbool.h>


### PR DESCRIPTION
Since the association of the directives being a similar format of instructions in jas (`instruction_t`), the instruction format has become overly complex and polluted of different operands, inputs and properties, unclear of correlation either to `enum instructions` or as part of the poorly designed `INSTR_DIR` prefixes. Since the integration of *unionised* directives, this pull has moved code associated with such behaviour outside to avoid wrongfully associating directives to be equivalent or similar to instructions.

From this point onwards, it should be noted that all `instruction_t` structs, as dubbed the `instr` property, **must** not deviate from documented x86 instructions. `instruction_t`, or any associated enums should not be used as part of custom information for the jas assembler, rather, *this `dir.h` file should be used.*