### PR TITLE
Supported `get_instr_tabs` with `instr_generic_t`

### DIFF
--- a/libjas/codegen.c
+++ b/libjas/codegen.c
@@ -41,15 +41,14 @@
     }                                                                   \
   } while (0)
 
-static instr_encode_table_t *get_instr_tabs(instruction_t *instr_arr, size_t arr_size) {
+static instr_encode_table_t *get_instr_tabs(instr_generic_t *instr_arr, size_t arr_size) {
   instr_encode_table_t *tabs = malloc(sizeof(instr_encode_table_t) * arr_size);
   for (size_t i = 0; i < arr_size; i++) {
-    if (IS_LABEL(instr_arr[i])) {
-      tabs[i] = INSTR_TAB_NULL;
-      continue;
-    }
-    tabs[i] = instr_get_tab(instr_arr[i]);
+    if (instr_arr[i].type != INSTR) continue;
+    
+    tabs[i] = instr_get_tab(instr_arr[i].instr);
   }
+
   return tabs;
 }
 


### PR DESCRIPTION
Despite ongoing disputes with the instruction enocder table struct's representation data structure, this pull has added the integration and migration of the `get_instr_tabs` function to support the usage of `get_instr_tabs` with generic structs.