### PR TITLE
Added missing includes

### DIFF
--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -25,6 +25,7 @@
 
 #include "instruction.h"
 #include "error.h"
+#include "operand.h"
 #include "register.h"
 #include "tabs.c"
 #include <stdarg.h>

--- a/libjas/parse.c
+++ b/libjas/parse.c
@@ -25,6 +25,8 @@
  */
 
 #include "parse.h"
+#include "error.h"
+#include "register.h"
 #include "tabs.c"
 #include <inttypes.h>
 #include <stdint.h>


### PR DESCRIPTION
This commit has added some previously missing includes for a couple header files. Despite passing builds previously, includes for some header files had been lost. Although unclear, it seems to be directed at an issue downstream from an overarching header file, rather than a circular-depency issue.