### PR TITLE
Fixed incorrectly labled conditonal validator

### DIFF
--- a/libjas/codegen.c
+++ b/libjas/codegen.c
@@ -136,7 +136,7 @@ static buffer_t assemble(enum modes mode, instruction_t *instr_arr, size_t arr_s
           op_sizeof(current.operands[j].type) >=
           op_sizeof(current.operands[j - 1].type);
 
-      if (!valid_operands) continue;
+      if (valid_operands) continue;
 
       err("invalid operand type");
       return BUF_NULL;


### PR DESCRIPTION
Previously, for some strange reason, the *`valid_operands`* boolean value has been setup to check with a negated boolean logic operator. Hence, all instructions that have been deemed *"valid"* by jas would have been flagged as having an "invalid operand type".