### PR TITLE
Moved checking of `OI` or `O` to `instruction.c`

### DIFF
--- a/libjas/operand.cpp
+++ b/libjas/operand.cpp
@@ -72,13 +72,6 @@ static multimap<enum enc_ident, uint32_t> master = {
     {ENC_M, __combine__(OP_HASH_M, OP_HASH_NONE, OP_HASH_NONE, OP_HASH_NONE)},
 };
 
-static bool ident_exists(enum enc_ident ident, instr_encode_table_t *instr_ref) {
-  for (auto j = 0; instr_ref[j].opcode_size > 0; j++)
-    if (instr_ref[j].ident == ident) return true;
-
-  return false;
-}
-
 extern "C" enum enc_ident op_ident_identify(enum operands *input, instr_encode_table_t *instr_ref) {
   uint32_t hash_key = 0;
 
@@ -97,18 +90,6 @@ extern "C" enum enc_ident op_ident_identify(enum operands *input, instr_encode_t
 
   if (lookup_table.find(hash_key) != lookup_table.end()) {
     enum enc_ident target = lookup_table.find(hash_key)->second;
-
-    bool o_exists = ident_exists(ENC_O, instr_ref);
-    bool oi_exists = ident_exists(ENC_OI, instr_ref);
-
-    if (o_exists || oi_exists) {
-      const uint32_t acc_hash = __combine__(OP_HASH_R, OP_HASH_IMM, OP_HASH_NONE, OP_HASH_NONE);
-
-      // Spaghetti code, would be ultimately removed
-      if (hash_key == acc_hash && o_exists) return ENC_O;
-      return ENC_OI;
-    }
-
     return target;
   } else {
     uint8_t k = 0;


### PR DESCRIPTION
This commit has moved the mechanism of checking for accumulator registers and their associated operand and encoder identities to the `instruciton.c` file. Due to significant confusion between `MR` and `OI` as well as `O` identities, this commit aims to re- solve this bug **after** the encoder identification proecess, thus allowing for more infromation to be accessed, thereby improving accuracy.