### PR TITLE
Removed encoder requirements of `IMM32` as maximum

### DIFF
--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -102,11 +102,6 @@ DEFINE_ENCODER(m) {
 }
 
 static void i_common(operand_t *op_arr, buffer_t *buf, instr_encode_table_t *instr_ref, enum modes mode) {
-  if (op_arr[1].type == OP_IMM64) {
-    err("operand type mismatch.");
-    return;
-  }
-
   const uint8_t imm_size = op_sizeof(op_arr[1].type) / 8;
   uint8_t *imm = (uint8_t *)op_arr[1].data;
   buf_write(buf, imm, imm_size);
@@ -133,6 +128,11 @@ DEFINE_ENCODER(d) {
 }
 
 DEFINE_ENCODER(mi) {
+  if (op_arr[1].type == OP_IMM64) {
+    err("operand type mismatch.");
+    return;
+  }
+
   m(op_arr, buf, instr_ref, mode, label_table, label_table_size);
   i_common(op_arr, buf, instr_ref, mode);
 }
@@ -200,14 +200,6 @@ DEFINE_ENCODER(mr) { rm_mr_common(op_arr, buf, instr_ref, mode, ENC_MR, label_ta
 DEFINE_ENCODER(rm) { rm_mr_common(op_arr, buf, instr_ref, mode, ENC_RM, label_table, label_table_size); }
 
 DEFINE_ENCODER(o) {
-  for (uint8_t i = 1; i < 4; i++) {
-    if (op_arr[i].type == OP_NULL) break;
-    if (op_sizeof(op_arr[i].type) != op_sizeof(op_arr[0].type)) {
-      err("operand type mismatch.");
-      return;
-    }
-  }
-
   enum registers register_data = *(enum registers *)op_arr[0].data;
   if (!op_acc(register_data)) err("Invalid operand, unexpected accumulator used.");
   size_t offset = (buf->len - 1) * sizeof(uint8_t);


### PR DESCRIPTION
Some instructions allows the usage of `IMM64` in regards to a 64-bit value in the inital operand. However, restrictions sitll remain in place for having a larger desination operand as compared to the resource.

It should be noted that yes, the typical `mov` instructions does not support the usage as such, which should'nt be confused with `movabs` when `OI` or `O` is used.