### PR TITLE
Removed operand checking for `mi`

### DIFF
--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -128,11 +128,6 @@ DEFINE_ENCODER(d) {
 }
 
 DEFINE_ENCODER(mi) {
-  if (op_arr[1].type == OP_IMM64) {
-    err("operand type mismatch.");
-    return;
-  }
-
   m(op_arr, buf, instr_ref, mode, label_table, label_table_size);
   i_common(op_arr, buf, instr_ref, mode);
 }


### PR DESCRIPTION
Quick and dirty fix for the broken `mi` ident, will eventually fix when the encoder logic is re worked.