### PR TITLE
Label evaluation function - `label_evaluate`

### DIFF
--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -71,7 +71,7 @@ typedef struct enc_serialized_instr {
   bool has_sib : 1;      /* SIB present */
 
   uint64_t disp; /* Displacement value (Big endian) */
-  uint64_t imm;  /* Immediate value  (Big endian) */
+  int64_t imm;   /* Immediate value  (Big endian) */
 
   /// @note A 0 size field depicts absence of the respective field.
   uint8_t disp_size : 4; /* Displacement size (0–8 bytes) */

--- a/libjas/include/label.h
+++ b/libjas/include/label.h
@@ -148,6 +148,24 @@ typedef struct label_table {
 } label_table_t;
 
 /**
+ * Function for facilitating the automatic computation of label
+ * relative offsets, across all operation modes. `label_evaluate`
+ * is designed purely for delegation between a label address and 
+ * current address and serialized instructions.
+ * 
+ * @param instr The serialized structure that lacks a label offset
+ * @param current The current address, till end of this instruction.
+ * @param label Address in offset of the label in question.
+ * @param mode Current operating mode for the encoder's target.
+ * 
+ * @return A pointer of the `instr` and indicative of success, 
+ * or of an error, where `NULL` is returned. 
+ */
+enc_serialized_instr_t *label_evaluate(
+    enc_serialized_instr_t *instr,
+    uint64_t current, uint64_t label, enum modes mode);
+
+/**
  * Function for generating an instruction generic structure for the
  * represented label, with relative ease of use. This function would
  * automatically create the instruction generic, leading to an instr-


### PR DESCRIPTION
This pull adds the `label_evaluate` function to the Jas source tree and serves as a stepping stone for the generation of labeled data. The function, as described by the commit message linked below, computes the label's offset based off provided values, apply them to the core instruction encoding. In general, the commit polishes Jas' support for labeled displacement values and its corresponding encodings, the commit messages of the branch should be consulted for extra details regarding changes.