### PR TITLE
Error enhancements

### DIFF
--- a/libjas/include/label.h
+++ b/libjas/include/label.h
@@ -116,9 +116,12 @@ void label_free(label_t *label);
  *
  * @param label_table The label table to store the label entry in.
  * @param input New table entry to be added to the label table.
+ *
+ * @return The success the of the label creation is indicated back
+ * to the caller. A non-zero value indicates failure.
  */
 
-void label_create(label_table_t *label_table, label_t input);
+uint8_t label_create(label_table_t *label_table, label_t input);
 
 // Macros that simplify label type checks, akin to the `op_` macros
 // that can be used with the `operand_t` structure and type checks.

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -130,7 +130,7 @@ instr_generic_t *instr_gen(enum instructions instr, uint8_t operand_count, ...) 
       case 64: write_imm_data(uint64_t); break;
       default:
         err("Invalid operand size.");
-        break;
+        return NULL;
       }
       // clang-format on
     } else {

--- a/libjas/label.c
+++ b/libjas/label.c
@@ -30,15 +30,19 @@
 #include <stdlib.h>
 #include <string.h>
 
-void label_create(label_table_t *label_table, label_t input) {
-  if (label_lookup(label_table, input.name))
-    return err("duplicated labels");
+uint8_t label_create(label_table_t *label_table, label_t input) {
+  if (label_lookup(label_table, input.name)) {
+    err("duplicated labels");
+    return 1;
+  }
 
   label_table->size++;
 
   size_t size = label_table->size * sizeof(label_t);
   label_table->entries = realloc(label_table->entries, size);
   label_table->entries[label_table->size - 1] = input;
+
+  return 0;
 }
 
 label_t *label_lookup(label_table_t *label_table, char *name) {

--- a/libjas/parse.c
+++ b/libjas/parse.c
@@ -66,12 +66,7 @@ uint64_t parse_str_num(char *name) {
     base = 16;
     name += 2;
   }
-
-  if (len > 16 && base == 16) {
-    err("Number is out of range");
-    return 0;
-  }
-
+  
   return strtoull(name, NULL, base);
 }
 


### PR DESCRIPTION
This is a copy from #132 which has been closed due to improper merging of the `main` branch. Effective commits that where deemed applicable for this merge has since been carried over through cherry picking over to this branch:

Details of the merge appears below, as copied over from #132:

This pull aims to standardize and streamline the reporting and indication of error or failing functions. Currently, many functions DO NOT have any means for the indication of failure expect the usage of the err callback function. From this pull onwards, it would be now standardized that all functions, including subsequent implementations of other methods would adhere to the standard as described in this commit:

Placeholder value in the return Functions will return an indicative value to identify whether an error has occurred during its execution time as established upon in the function signature, or documentation remarks. This should typically be set as an empty value such as a NULL value for pointers; or a padded 0 value such as the header provided constants like INSTR_TAB_NULL for instr_encode_table_t etc.

Details available within error log As opposed to the usage of the error callback as the sole form of indication of an error, a revised standard now allows callers to decide whether to use a simplified true or false conditional for an error, or an extensive description as passed in by the caller defined callback function.

Furthermore, the usage of this standard may allow for minimal assembly funcitons. In such implementations of the Jas assembler, the caller may choose to ignore the callback and provide minimal error description and purely focusing on status reporting instead.

Warning

Some compiler function declarations may be incompatible with previous definitions and should be treated as a breaking change!