### PR TITLE
Add instructions support for `add`, `sub`, `or` and `xor`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,6 @@ the prerequisites for building and developing Jas appear below.
 
 <!-- @mdformat resume -->
 
-
 - `lldb` _if wishing to debug the Jas assembler_
 
 ### Building & debugging

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ debugging can be found
 
 ### 📖 Documentation
 
-The Jas documentation website is accessible online [here]() and can be built
+The Jas documentation website is accessible online [here](<>) and can be built
 and served locally by running and statically serving the `mkdocs.yml` file via
 the `mkdocs` command line tool. The Jas assembler documentation website provides
 a reference for the assembler's function as well as step by step guides for
@@ -128,7 +128,7 @@ repository!
 All changes and reports are welcome, no matter how big or small your changes are
 :-)
 
----
+______________________________________________________________________
 
 _Made with love by Alvin / the Jas crew and contributors ❤️ ._
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ that's the beauty of Jas!
 #include <stdlib.h>
 
 int main(void) {
-  instr_generic_t *instr = instr_gen(INSTR_MOV, 2, r64(REG_RAX), imm64(0));
+  instr_generic_t *instr = instr_gen(INSTR_MOV, 2, r64(REG_RAX), imm32(0));
   buffer_t buf = assemble_instr(MODE_LONG, instr);
 
   /* Do something to `buf.data` - The uint8_t array */
@@ -95,7 +95,7 @@ debugging can be found
 
 ### 📖 Documentation
 
-The Jas documentation website is accessible online [here](<>) and can be built
+The Jas documentation website is accessible online [here]() and can be built
 and served locally by running and statically serving the `mkdocs.yml` file via
 the `mkdocs` command line tool. The Jas assembler documentation website provides
 a reference for the assembler's function as well as step by step guides for
@@ -128,7 +128,7 @@ repository!
 All changes and reports are welcome, no matter how big or small your changes are
 :-)
 
-______________________________________________________________________
+---
 
 _Made with love by Alvin / the Jas crew and contributors ❤️ ._
 

--- a/libjas/codegen.c
+++ b/libjas/codegen.c
@@ -22,4 +22,3 @@
  *
  * @see `LICENSE`
  */
-

--- a/libjas/encoders/add.yml
+++ b/libjas/encoders/add.yml
@@ -28,7 +28,7 @@ instructions:
       - opcode: [0x81]
         operands:
           - { type: r/m64, encoder: /4 }
-          - { type: imm64, encoder: default }
+          - { type: imm32, encoder: default }
         compatibility:
           long: true
           legacy: false

--- a/libjas/encoders/add.yml
+++ b/libjas/encoders/add.yml
@@ -1,0 +1,122 @@
+instructions:
+  - and:
+    variants:
+      - opcode: [0x80]
+        operands:
+          - { type: r/m8, encoder: /4 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m16, encoder: /4 }
+          - { type: imm16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m32, encoder: /4 }
+          - { type: imm32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m64, encoder: /4 }
+          - { type: imm64, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m16, encoder: /4 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m32, encoder: /4 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m64, encoder: /4 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x20]
+        operands:
+          - { type: r/m8, encoder: r/m }
+          - { type: r8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x21]
+        operands:
+          - { type: r/m16, encoder: r/m }
+          - { type: r16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x21]
+        operands:
+          - { type: r/m32, encoder: r/m }
+          - { type: r32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x21]
+        operands:
+          - { type: r/m64, encoder: r/m }
+          - { type: r64, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x22]
+        operands:
+          - { type: r8, encoder: default }
+          - { type: r/m8, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x23]
+        operands:
+          - { type: r16, encoder: default }
+          - { type: r/m16, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x23]
+        operands:
+          - { type: r32, encoder: default }
+          - { type: r/m32, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x23]
+        operands:
+          - { type: r64, encoder: default }
+          - { type: r/m64, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: false

--- a/libjas/encoders/mov.yml
+++ b/libjas/encoders/mov.yml
@@ -92,7 +92,7 @@ instructions:
       - opcode: [0xB8]
         operands:
           - { type: r64, encoder: opcode_appended }
-          - { type: imm64, encoder: default }
+          - { type: imm32, encoder: default }
         compatibility:
           long: true
           legacy: false
@@ -124,7 +124,7 @@ instructions:
       - opcode: [0xC7]
         operands:
           - { type: r/m64, encoder: /0 }
-          - { type: imm64, encoder: default }
+          - { type: imm32, encoder: default }
         compatibility:
           long: true
           legacy: false

--- a/libjas/encoders/or.yml
+++ b/libjas/encoders/or.yml
@@ -28,7 +28,7 @@ instructions:
       - opcode: [0x81]
         operands:
           - { type: r/m64, encoder: /1 }
-          - { type: imm64, encoder: default }
+          - { type: imm32, encoder: default }
         compatibility:
           long: true
           legacy: false
@@ -56,7 +56,7 @@ instructions:
         compatibility:
           long: true
           legacy: false
-          
+
       - opcode: [0x08]
         operands:
           - { type: r/m8, encoder: r/m }

--- a/libjas/encoders/or.yml
+++ b/libjas/encoders/or.yml
@@ -1,0 +1,122 @@
+instructions:
+  - or:
+    variants:
+      - opcode: [0x80]
+        operands:
+          - { type: r/m8, encoder: /1 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m16, encoder: /1 }
+          - { type: imm16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m32, encoder: /1 }
+          - { type: imm32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m64, encoder: /1 }
+          - { type: imm64, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m16, encoder: /1 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m32, encoder: /1 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m64, encoder: /1 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+          
+      - opcode: [0x08]
+        operands:
+          - { type: r/m8, encoder: r/m }
+          - { type: r8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x09]
+        operands:
+          - { type: r/m16, encoder: r/m }
+          - { type: r16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x09]
+        operands:
+          - { type: r/m32, encoder: r/m }
+          - { type: r32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x09]
+        operands:
+          - { type: r/m64, encoder: r/m }
+          - { type: r64, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x0A]
+        operands:
+          - { type: r8, encoder: default }
+          - { type: r/m8, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x0B]
+        operands:
+          - { type: r16, encoder: default }
+          - { type: r/m16, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x0B]
+        operands:
+          - { type: r32, encoder: default }
+          - { type: r/m32, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x0B]
+        operands:
+          - { type: r64, encoder: default }
+          - { type: r/m64, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: false

--- a/libjas/encoders/sub.yml
+++ b/libjas/encoders/sub.yml
@@ -28,7 +28,7 @@ instructions:
       - opcode: [0x81]
         operands:
           - { type: r/m64, encoder: /5 }
-          - { type: imm64, encoder: default }
+          - { type: imm32, encoder: default }
         compatibility:
           long: true
           legacy: false

--- a/libjas/encoders/sub.yml
+++ b/libjas/encoders/sub.yml
@@ -1,0 +1,122 @@
+instructions:
+  - sub:
+    variants:
+      - opcode: [0x80]
+        operands:
+          - { type: r/m8, encoder: /5 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m16, encoder: /5 }
+          - { type: imm16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m32, encoder: /5 }
+          - { type: imm32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m64, encoder: /5 }
+          - { type: imm64, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m16, encoder: /5 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m32, encoder: /5 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m64, encoder: /5 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x28]
+        operands:
+          - { type: r/m8, encoder: r/m }
+          - { type: r8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x29]
+        operands:
+          - { type: r/m16, encoder: r/m }
+          - { type: r16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x29]
+        operands:
+          - { type: r/m32, encoder: r/m }
+          - { type: r32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x29]
+        operands:
+          - { type: r/m64, encoder: r/m }
+          - { type: r64, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x2A]
+        operands:
+          - { type: r8, encoder: default }
+          - { type: r/m8, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x2B]
+        operands:
+          - { type: r16, encoder: default }
+          - { type: r/m16, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x2B]
+        operands:
+          - { type: r32, encoder: default }
+          - { type: r/m32, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x2B]
+        operands:
+          - { type: r64, encoder: default }
+          - { type: r/m64, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: false

--- a/libjas/encoders/xor.yml
+++ b/libjas/encoders/xor.yml
@@ -28,7 +28,7 @@ instructions:
       - opcode: [0x81]
         operands:
           - { type: r/m64, encoder: /6 }
-          - { type: imm64, encoder: default }
+          - { type: imm32, encoder: default }
         compatibility:
           long: true
           legacy: false

--- a/libjas/encoders/xor.yml
+++ b/libjas/encoders/xor.yml
@@ -1,0 +1,122 @@
+instructions:
+  - xor:
+    variants:
+      - opcode: [0x80]
+        operands:
+          - { type: r/m8, encoder: /6 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m16, encoder: /6 }
+          - { type: imm16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m32, encoder: /6 }
+          - { type: imm32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x81]
+        operands:
+          - { type: r/m64, encoder: /6 }
+          - { type: imm64, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m16, encoder: /6 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m32, encoder: /6 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x83]
+        operands:
+          - { type: r/m64, encoder: /6 }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x30]
+        operands:
+          - { type: r/m8, encoder: r/m }
+          - { type: r8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x31]
+        operands:
+          - { type: r/m16, encoder: r/m }
+          - { type: r16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x31]
+        operands:
+          - { type: r/m32, encoder: r/m }
+          - { type: r32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x31]
+        operands:
+          - { type: r/m64, encoder: r/m }
+          - { type: r64, encoder: default }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x32]
+        operands:
+          - { type: r8, encoder: default }
+          - { type: r/m8, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x33]
+        operands:
+          - { type: r16, encoder: default }
+          - { type: r/m16, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x33]
+        operands:
+          - { type: r32, encoder: default }
+          - { type: r/m32, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x33]
+        operands:
+          - { type: r64, encoder: default }
+          - { type: r/m64, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: false


### PR DESCRIPTION
This pull request adds support for the basic `add`, `sub, `or` and `xor` instructions by adding their relevant encoder reference tables for the respective instructions. Most encoding identities for said instructions has been added and handled expect for ones requiring the encoding of literal general-purpose registers. For instance, instructions which explicitly utilise literal operands, as opposed to generalised *operand classes* are currently unsupported at this stage in time. 

Specifically, instruction encoder rules such as `add rax, imm32` would be encoded as `REX.W 0x05 id`. However, as of now, Jas is *unable* separately identity said rules and generalises said instruction to `add r/m64, imm32` instead. The current feature set would require an extra encoded ModR/M byte to specify the reference to `rax` instead of implicitly suggesting through the opcode.

Due to not being able to support literal values, committed encoder reference tables does *not* currently include these instructions, with a future fix being implemented shortly.