### PR TITLE
Error check for displacement sizes greater than 32-bits

### DIFF
--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -45,6 +45,15 @@ enum op_modrm_modes op_modrm_mode(uint64_t displacement, uint8_t *sz) {
   if (!displacement) mode_return(0, OP_MODRM_MODE_INDIRECT);
   if (displacement <= UCHAR_MAX) mode_return(1, OP_MODRM_MODE_DISP8);
 
+  /// @note Although the x86 architecture supports 64-bit dis-
+  /// placements, the ModR/M byte only supports up to double word
+  /// displacements. 
+
+  if (displacement > UINT32_MAX) {
+    err("displacement exceeds 32-bit limit");
+    return OP_MODRM_MODE_INDIRECT;
+  }
+
   mode_return(4, OP_MODRM_MODE_DISP32);
 }
 


### PR DESCRIPTION
This pull adds error checking for the `op_modrm_mode` function’s size checking functionality, filtering out displacements larger than *32-bits* wide. Despite having a `displacement` value supporting a size of `uint64_t`, most *scalar* instructions may only have displacements of 32-bits wide instead of the full 8 byte allowed. The allocation of 8 bytes for the displacement values allows implementation of vector-oriented instructions down the road.