### PR TITLE
Added support for custom instruction encoder tables in `rex_apply`

### DIFF
--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -46,8 +46,7 @@ struct enc_serialized_instr *enc_serialize(instr_generic_t *input, enum modes mo
   // Preliminary error checking done, proceed with encoding
   // and the generation of serialized instruction.
 
-  struct enc_serialized_instr *serialized =
-      calloc(1, sizeof(enc_serialized_instr_t));
+  struct enc_serialized_instr *serialized = (enc_serialized_instr_t){0};
 
   op_write_prefix(&serialized->prefixes, instr.operands, mode);
   serialized->rex = rex_apply(&instr);

--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -46,10 +46,11 @@ struct enc_serialized_instr *enc_serialize(instr_generic_t *input, enum modes mo
   // Preliminary error checking done, proceed with encoding
   // and the generation of serialized instruction.
 
-  struct enc_serialized_instr *serialized = (enc_serialized_instr_t){0};
+  struct enc_serialized_instr *serialized =
+      calloc(1, sizeof(struct enc_serialized_instr));
 
   op_write_prefix(&serialized->prefixes, instr.operands, mode);
-  serialized->rex = rex_apply(&instr);
+  serialized->rex = rex_apply(&instr, &tab);
 
   memcpy(serialized->opcode, tab.opcode, tab.opcode_size);
   serialized->opcode_size = tab.opcode_size;

--- a/libjas/include/rex.h
+++ b/libjas/include/rex.h
@@ -20,7 +20,7 @@
  * out of or in connection with the software or the use or other dealings in the
  * software.
  *
- * @see `license`
+ * @see `LICENSE`
  */
 
 #ifndef REX_H
@@ -59,6 +59,7 @@ typedef uint8_t rex_t;
 
 /// @note forward declaration to prevent circular dependency.
 typedef struct instruction instruction_t;
+typedef struct instr_encode_table instr_encode_table_t;
 
 /**
  * Function for applying the REX prefix to the instruction based
@@ -67,8 +68,10 @@ typedef struct instruction instruction_t;
  * the instruction.
  *
  * @param input The instruction generic pointer
+ * @param input_tab Optional pointer to an instruction table.
+ *
  * @return The final resulting REX prefix byte.
  */
-rex_t rex_apply(instruction_t *input);
+rex_t rex_apply(instruction_t *input, instr_encode_table_t *input_tab);
 
 #endif

--- a/libjas/rex.c
+++ b/libjas/rex.c
@@ -24,25 +24,27 @@
  */
 
 #include "rex.h"
+#include "instruction.h"
 
-rex_t rex_apply(instruction_t *input) {
+rex_t rex_apply(instruction_t *input, instr_encode_table_t *input_tab) {
   rex_t rex = REX_DEFAULT;
   instr_encode_table_t tab = (instr_encode_table_t){0};
+  if (input_tab) tab = *input_tab;
 
   for (uint8_t i = 0; i < 4; i++) {
     const operand_t op = input->operands[i];
-    if (op.type == OP_NULL) break;
 
+    if (op.type == OP_NULL) break;
     if (op_sizeof(op.type) == 64) rex |= REX_W;
 
     /// @note such usage of REX fields is only applicable
-    /// in context of SIB-based memory operands and register
-    /// usage!
+    /// in context of SIB-based memory operands and register!
+
     if (op_rm(op.type) && op.mem.src_type == SIB) {
       if (!tab.opcode_size) tab = instr_get_tab(*input);
 
       const enum enc_ident option =
-          tab.operand_descriptors[i].encoder;
+        tab.operand_descriptors[i].encoder;
 
       if (option == ENC_DEFAULT) rex |= REX_R;
       if (reg_needs_rex(op.mem.src.sib.reg_disp)) rex |= REX_X;


### PR DESCRIPTION
Previously, the addition of a REX prefix required the recomputing of instruction encoding table in order to compare the operand structure to the provided `input`, this means, the expensive call for the `instr_get_tab` is repeated for every call of `rex_apply` itself, which itself may be embedded within an encoder function. 

This pull allows the caller to pass in a custom instruction encoder table to have the REX operations be placed upon. This saves the requirement for an additional computation per call of encoder functions where not entirely necessary. Where the preprocessing of the instruction encoder table is not applicable, this behaviour can also be inhibited by passing the `NULL` value in place of `input_tab`.