### PR TITLE
Operand displacement size mix-up with operand data size

### DIFF
--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -60,7 +60,7 @@ struct enc_serialized_instr *enc_serialize(instr_generic_t *input, enum modes mo
     enum enc_ident option = tab.operand_descriptors[i].encoder;
 
     if (option == ENC_IGNORE) continue;
-    uint8_t operand_size = op_sizeof(instr.operands[i].type);
+    uint8_t operand_size = op_disp_size(instr.operands[i].type);
 
     if (op_rel(instr.operands[i].type)) {
       serialized->disp_size = operand_size;

--- a/libjas/include/operand.h
+++ b/libjas/include/operand.h
@@ -246,6 +246,19 @@ void op_write_prefix(buffer_t *buf, operand_t *op_arr, enum modes mode);
 uint8_t op_sizeof(enum operands input);
 
 /**
+ * Function for determining the size of the displacement value in
+ * bytes, based on the value of the displacement itself. This is
+ * used to determine the size of the displacement field in the
+ * instruction encoding.
+ *
+ * @param displacement The value of the displacement to be checked.
+ *
+ * @return The size of the displacement in bytes, or 0 when there
+ * is no, or excess displacement of 32-bits limit.
+ */
+uint8_t op_disp_size(uint64_t displacement);
+
+/**
  * Function for asserting that the types of the input operand
  * array matches the expected operand types provided in the
  * expected operand array.

--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -41,18 +41,24 @@ bool op_assert_types(operand_t *in, enum operands *ex, size_t sz) {
 // clang-format off
 #define mode_return(size, mode) { if (sz) *sz = size; return mode; }
 
+uint8_t op_disp_size(uint64_t displacement) {
+  if (!displacement) return 0;
+  if (displacement <= UCHAR_MAX) return 1;
+  if (displacement <= UINT32_MAX) return 4;
+
+  err("displacement exceeds 32-bit limit");
+  return 0;
+}
+
 enum op_modrm_modes op_modrm_mode(uint64_t displacement, uint8_t *sz) {
-  if (!displacement) mode_return(0, OP_MODRM_MODE_INDIRECT);
-  if (displacement <= UCHAR_MAX) mode_return(1, OP_MODRM_MODE_DISP8);
+  uint8_t disp_size = op_disp_size(displacement);
+
+  if (!disp_size) mode_return(0, OP_MODRM_MODE_INDIRECT);
+  if (disp_size == 1) mode_return(1, OP_MODRM_MODE_DISP8);
 
   /// @note Although the x86 architecture supports 64-bit dis-
   /// placements, the ModR/M byte only supports up to double word
   /// displacements. 
-
-  if (displacement > UINT32_MAX) {
-    err("displacement exceeds 32-bit limit");
-    return OP_MODRM_MODE_INDIRECT;
-  }
 
   mode_return(4, OP_MODRM_MODE_DISP32);
 }


### PR DESCRIPTION
This pull addresses an issue found in the encoder module in which the *actual* size of the displacement value was mixed-up with the *data* size in which the operand represents. Specifically, the `enc_serialize` function's assignment for the `imm_size` and `disp_size` values of the `enc_serialized_instr` structure _both was assigned with the data size of the operand instead of the actual size_.

This pull addresses the issue by encapsulating the behaviour for the validation and determination of operand sizes through the `op_disp_size` function. Callers are able to determine the size of the integer values by calling said function.