### PR TITLE
Implemented `encoded_size` attribute to `enc_serialized_instr` structure

### DIFF
--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -161,6 +161,12 @@ struct enc_serialized_instr *enc_serialize(instr_generic_t *input, enum modes mo
     }
   }
 
+  serialized->encoded_size =
+      serialized->prefixes.len +
+      serialized->rex + serialized->opcode_size +
+      serialized->has_modrm + serialized->has_sib +
+      serialized->disp_size + serialized->imm_size;
+
   return serialized;
 }
 

--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -77,6 +77,8 @@ typedef struct enc_serialized_instr {
   uint8_t disp_size : 4; /* Displacement size (0–8 bytes) */
   uint8_t imm_size : 4;  /* Immediate size (0–8 bytes) */
 
+  uint8_t encoded_size; /* Sum of the total encoded bytes */
+
 } enc_serialized_instr_t;
 
 /**

--- a/libjas/label.c
+++ b/libjas/label.c
@@ -70,11 +70,7 @@ enc_serialized_instr_t *label_evaluate(
   int64_t effective_offset = label;
   if (mode != MODE_LONG && is_mem) goto default_operand;
 
-  uint8_t instr_size =
-      instr->prefixes.len +
-      instr->rex + instr->opcode_size +
-      instr->has_modrm + instr->has_sib +
-      instr->disp_size + instr->imm_size;
+  uint8_t instr_size = instr->encoded_size;
 
   /// @note how an offset of 0x00 is a valid offset of the
   /// next instruction **following** the current instruction


### PR DESCRIPTION
This commit adds the `encoded_size` attribute to the serialized instruction structure as well as the corresponding calculations to populate said value in the `enc_serialize` function. The value represents the total size of the instruction (in bytes) if the instruction was to be deserialised, and compiled into a flat instruction.

Through computing and adding all values associated with the sizes of the respective values, the total size of the instruction can be added up for future uses in other functions and modules, without recalculation or redundancy code. 

For instance, the ELF or label modules may use the `encoded_size` to quickly compute offsets or displacements from another instruction, as well as calculating the total size of a segment of code etc.