### PR TITLE
Added support for LEA instruction 

### DIFF
--- a/libjas/encoders/lea.yml
+++ b/libjas/encoders/lea.yml
@@ -1,0 +1,26 @@
+instructions:
+  - lea:
+    variants:
+      - opcode: [0x8D]
+        operands:
+          - { type: r16, encoder: default }
+          - { type: m, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x8D]
+        operands:
+          - { type: r32, encoder: default }
+          - { type: m, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x8D]
+        operands:
+          - { type: r64, encoder: default }
+          - { type: m, encoder: r/m }
+        compatibility:
+          long: true
+          legacy: false


### PR DESCRIPTION
This pull adds the instruction encoder table for the LEA instruction (Load effective address). Please note that this instruction encoder table uses the newly implemented *shorthand* notation where a general operand may be specified and all other sizes be inferred.

The said feature was implemented as part of the compiler script in the pull request number #142. Please view the corresponding pull for more details as the details are yet to be documented in the Jas documentation.