### PR TITLE
Instruction compiler fixes

### DIFF
--- a/libjas/encoders/scripts/compile.js
+++ b/libjas/encoders/scripts/compile.js
@@ -187,7 +187,7 @@ function handleVariant(variant) {
 }
 
 function generateEnumNames(instructions) {
-  let instrEnumEntries = "enum instr_enum {\n";
+  let instrEnumEntries = "enum instructions {\n";
 
   let instructionNames = ["null = 0", ...instructions];
   for (let m = 0; m < instructionNames.length; m++) {

--- a/libjas/encoders/scripts/compile.js
+++ b/libjas/encoders/scripts/compile.js
@@ -124,16 +124,18 @@ function handleOperands(operands) {
   return `{${res}${"{ 0 }, ".repeat(4 - operands.length)}}`;
 }
 
-// clang-format off
-let output =
-  "// Auto-generated file. Do not edit directly. \n\n" +
+let output = "";
+
+let includes =
   "#include <stdbool.h> \n" +
   '#include "instruction.h" \n' +
   '#include "operand.h" \n' +
-  '#include "encoder.h" \n\n' +
-  "#ifndef INSTR_ENUM \n";
-// clang-format on
+  '#include "encoder.h" \n';
 
+let headerComment = "// Auto-generated file. Do not edit directly. \n\n";
+let guard = "#ifdef INSTR_ENCODER_TAB \n";
+
+output += headerComment + guard + includes;
 output += `struct instr_encode_table *instr_table[] = {`;
 
 for (let k = 0; k < instructions.length; k++) {
@@ -145,24 +147,23 @@ for (let k = 0; k < instructions.length; k++) {
 
   output += " (instr_encode_table_t){0},},";
 }
-output += "}; \n#endif";
+let trailingGuard = "}; \n#undef INSTR_ENCODER_TAB \n#endif";
+output += trailingGuard;
 
-let instrEnumEntries = "#ifdef INSTR_ENUM \n" + "enum instructions {\n";
+output += "\n\n"; // -----------------------------------
 
-instructionNames = ["null = 0", ...instructionNames];
-for (let m = 0; m < instructionNames.length; m++) {
-  instrEnumEntries += `  INSTR_${instructionNames[m].toUpperCase()},\n`;
-}
-instrEnumEntries += "};\n";
+let instrEnumBoiler = "#ifdef INSTR_ENUM \n";
+output += instrEnumBoiler;
 
-instrEnumEntries += "char *instr_tab_names[] = {\n";
-for (let n = 1; n < instructionNames.length; n++)
-  instrEnumEntries += `  "${instructionNames[n]}",`;
+output += generateEnumNames(instructionNames);
+output += generateInstructionNames(instructionNames);
 
-instrEnumEntries += "};\n";
-instrEnumEntries += "#undef INSTR_ENUM\n#endif";
+output += "};\n";
+output += "#undef INSTR_ENUM\n#endif";
 
-console.log(output + "\n\n" + instrEnumEntries);
+// ---
+
+console.log(output);
 
 function handleVariant(variant) {
   let res = "";
@@ -183,4 +184,25 @@ function handleVariant(variant) {
   res += `.operand_count = ${variant.operands.length},`;
 
   return `{ ${res} },`;
+}
+
+function generateEnumNames(instructions) {
+  let instrEnumEntries = "enum instr_enum {\n";
+
+  let instructionNames = ["null = 0", ...instructions];
+  for (let m = 0; m < instructionNames.length; m++) {
+    instrEnumEntries += `  INSTR_${instructionNames[m].toUpperCase()},\n`;
+  }
+  instrEnumEntries += "};\n";
+
+  return instrEnumEntries;
+}
+
+function generateInstructionNames(names) {
+  let instrNames = "char *instr_tab_names[] = {\n";
+  for (let n = 1; n < names.length; n++) {
+    instrNames += `  "${names[n]}",`;
+  }
+
+  return instrNames;
 }

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -38,6 +38,8 @@
 
 #define CURR_TABLE instr_table[(uint8_t)instr.instr]
 instr_encode_table_t instr_get_tab(instruction_t instr) {
+
+  #define INSTR_ENCODER_TAB
   #include "instructions.inc"
   // clang-format on
 


### PR DESCRIPTION
This pull fixes previous issues associated with the generated output of the `instructions.inc` file. Specifically, this pull request rectifies the circular dependency bug when the `instructions.inc` file is included as part of the `instruction.h` file.

Additionally, this pull has also encapsulated output generation steps into functions, such as the steps generating the instruction names enum and string array among other items.