### PR TITLE
Added support for the `not` instruction

### DIFF
--- a/libjas/encoders/not.yml
+++ b/libjas/encoders/not.yml
@@ -1,0 +1,27 @@
+instructions:
+  - not:
+    variants:
+      - opcode: [0xF6]
+        operands:
+          - { type: r/m8, encoder: /2 }
+        compatibility:
+          long: true
+          legacy: true
+      - opcode: [0xF7]
+        operands:
+          - { type: r/m16, encoder: /2 }
+        compatibility:
+          long: true
+          legacy: true
+      - opcode: [0xF7]
+        operands:
+          - { type: r/m32, encoder: /2 }
+        compatibility:
+          long: true
+          legacy: true
+      - opcode: [0xF7]
+        operands:
+          - { type: r/m64, encoder: /2 }
+        compatibility:
+          long: true
+          legacy: false


### PR DESCRIPTION
This commit adds the instruction encoder reference table for `not`. The direct `.csv` file can be viewed [here](https://docs.google.com/spreadsheets/d/15PK5Q9vjjYKEJWAXPftXyjC4Z2HC6BZjVgo1rBCBqss/edit?gid=232363913#gid=232363913)