### PR TITLE
Added support for the `dec` instruction

### DIFF
--- a/libjas/encoders/dec.yml
+++ b/libjas/encoders/dec.yml
@@ -1,0 +1,44 @@
+instructions:
+  - dec:
+    variants:
+      - opcode: [0xFE]
+        operands:
+          - { type: r/m8, encoder: /1 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m16, encoder: /1 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m32, encoder: /1 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m64, encoder: /1 }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x48]
+        operands:
+          - { type: r16, encoder: opcode_appended }
+        compatibility:
+          long: false
+          legacy: true
+          
+      - opcode: [0x48]
+        operands:
+          - { type: r32, encoder: opcode_appended }
+        compatibility:
+          long: false
+          legacy: true


### PR DESCRIPTION
This commit adds support for the `dec` instruction, the encoder reference table is generated based off the `.csv` file found in the Google Drive [here](https://docs.google.com/spreadsheets/d/15PK5Q9vjjYKEJWAXPftXyjC4Z2HC6BZjVgo1rBCBqss/edit?gid=232363913#gid=232363913).

It should be noted that this instruction is one of the first instructions that utilises the `ENC_OPERAND_APPENDED` encoder modifier enum. Further testing should be completed, including a compilation test of the `compiler.js` script to ensure correct expression of the operand modifier; especially in future implementations of instructions akin to `dec`.