### PR TITLE
Added encoder reference table for `inc`

### DIFF
--- a/libjas/encoders/inc.yml
+++ b/libjas/encoders/inc.yml
@@ -1,0 +1,44 @@
+instructions:
+  - inc:
+    variants:
+      - opcode: [0xFE]
+        operands:
+          - { type: r/m8, encoder: /0 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m16, encoder: /0 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m32, encoder: /0 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m64, encoder: /0 }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x40]
+        operands:
+          - { type: r16, encoder: opcode_appended }
+        compatibility:
+          long: false
+          legacy: true
+
+      - opcode: [0x40]
+        operands:
+          - { type: r32, encoder: opcode_appended }
+        compatibility:
+          long: false
+          legacy: true


### PR DESCRIPTION
This pull adds support of the `inc` instruction by adding its encoder reference table to the registry. The original source `.csv` file can be found [here](https://docs.google.com/spreadsheets/d/15PK5Q9vjjYKEJWAXPftXyjC4Z2HC6BZjVgo1rBCBqss/edit?gid=232363913#gid=232363913)

