### PR TITLE
Add support for the ret instruction

### DIFF
--- a/libjas/encoders/ret.yml
+++ b/libjas/encoders/ret.yml
@@ -1,0 +1,14 @@
+instructions:
+  - ret:
+    variants:
+      - opcode: [0xC3]
+        operands: []
+        compatibility:
+          long: true
+          legacy: true
+      - opcode: [0xC2]
+        operands:
+          - { type: imm16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true


### PR DESCRIPTION
This pull adds support for the `ret` (return) instruction by adding its corresponding instruction encoding reference table to the `encoders` directory, the original `.csv` file this instruction was compiled from can found in [this file](https://docs.google.com/spreadsheets/d/1clyQtF-ZYd0qBIEQYGdVVd0FmLsOE4lhin7utJNIdbs/edit?gid=232363913#gid=232363913)

The Intel developer's manual listing the `ret` instruction specifies two variants of the `ret` instruction, which includes a *far-return* or a *near-return*. As the current state of the ELF generation and calling systems are in development and yet to be confirmed, **only the near-return instruction is support as of right now**. Support of the *far-return* instruction is forthcoming in the near future.