### PR TITLE
Implementation of new instructions

### DIFF
--- a/libjas/encoders/dec.yml
+++ b/libjas/encoders/dec.yml
@@ -1,0 +1,44 @@
+instructions:
+  - dec:
+    variants:
+      - opcode: [0xFE]
+        operands:
+          - { type: r/m8, encoder: /1 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m16, encoder: /1 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m32, encoder: /1 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m64, encoder: /1 }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x48]
+        operands:
+          - { type: r16, encoder: opcode_appended }
+        compatibility:
+          long: false
+          legacy: true
+          
+      - opcode: [0x48]
+        operands:
+          - { type: r32, encoder: opcode_appended }
+        compatibility:
+          long: false
+          legacy: true

--- a/libjas/encoders/inc.yml
+++ b/libjas/encoders/inc.yml
@@ -1,0 +1,44 @@
+instructions:
+  - inc:
+    variants:
+      - opcode: [0xFE]
+        operands:
+          - { type: r/m8, encoder: /0 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m16, encoder: /0 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m32, encoder: /0 }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0xFF]
+        operands:
+          - { type: r/m64, encoder: /0 }
+        compatibility:
+          long: true
+          legacy: false
+
+      - opcode: [0x40]
+        operands:
+          - { type: r16, encoder: opcode_appended }
+        compatibility:
+          long: false
+          legacy: true
+
+      - opcode: [0x40]
+        operands:
+          - { type: r32, encoder: opcode_appended }
+        compatibility:
+          long: false
+          legacy: true

--- a/libjas/encoders/not.yml
+++ b/libjas/encoders/not.yml
@@ -1,0 +1,27 @@
+instructions:
+  - not:
+    variants:
+      - opcode: [0xF6]
+        operands:
+          - { type: r/m8, encoder: /2 }
+        compatibility:
+          long: true
+          legacy: true
+      - opcode: [0xF7]
+        operands:
+          - { type: r/m16, encoder: /2 }
+        compatibility:
+          long: true
+          legacy: true
+      - opcode: [0xF7]
+        operands:
+          - { type: r/m32, encoder: /2 }
+        compatibility:
+          long: true
+          legacy: true
+      - opcode: [0xF7]
+        operands:
+          - { type: r/m64, encoder: /2 }
+        compatibility:
+          long: true
+          legacy: false

--- a/libjas/encoders/ret.yml
+++ b/libjas/encoders/ret.yml
@@ -1,0 +1,14 @@
+instructions:
+  - ret:
+    variants:
+      - opcode: [0xC3]
+        operands: []
+        compatibility:
+          long: true
+          legacy: true
+      - opcode: [0xC2]
+        operands:
+          - { type: imm16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true


### PR DESCRIPTION
This pull adds the encoder reference tables for the `inc`, `ret`, `dec` and `not` instructions, therefore supporting said instructions as part of the assembler's instruction set.

**Outstanding notes:**
* Please note that `ret` only supports *near-return* and near-calling as the current situation with regards to the ELF table generation and label evaluation is to be confirmed
* Instructions using the `ENC_OPCODE_APPENDED` encoder modifier, or corresponding to the`+rw` and `+rb` modifiers as specified by Intel , is untested and may require verification of its functionality.

For more detail, view the respective commit's own descriptions.