### PR TITLE
Add support for literal operands

### DIFF
--- a/libjas/encoder.c
+++ b/libjas/encoder.c
@@ -59,7 +59,7 @@ struct enc_serialized_instr *enc_serialize(instr_generic_t *input, enum modes mo
     op_mem_src_t mem_src = instr.operands[i].mem.src;
     enum enc_ident option = tab.operand_descriptors[i].encoder;
 
-    if (option == ENC_IGNORE) continue;
+    if (option == ENC_IGNORE && option == ENC_LITERAL) continue;
     uint8_t operand_size = op_disp_size(instr.operands[i].type);
 
     if (op_rel(instr.operands[i].type)) {

--- a/libjas/encoders/add.yml
+++ b/libjas/encoders/add.yml
@@ -1,6 +1,38 @@
 instructions:
   - add:
     variants:
+      - opcode: [0x04]
+        operands:
+          - { type: r8, encoder: literal, value: al }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x05]
+        operands:
+          - { type: r16, encoder: literal, value: ax }
+          - { type: imm16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x05]
+        operands:
+          - { type: r32, encoder: literal, value: eax }
+          - { type: imm32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x05]
+        operands:
+          - { type: r64, encoder: literal, value: rax }
+          - { type: imm32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
       - opcode: [0x80]
         operands:
           - { type: r/m8, encoder: /4 }

--- a/libjas/encoders/scripts/compile.js
+++ b/libjas/encoders/scripts/compile.js
@@ -27,28 +27,28 @@
  * @note `js-yaml` package must be installed and accessible to allow
  * yaml parsing functionality to be used.
  *
- * Encoder options are to be filled in each operand definition's 
+ * Encoder options are to be filled in each operand definition's
  * `encoder` field. The value of the `encoder` field is to either
- * map to a predefined encoder enum, or be an integer value from 
+ * map to a predefined encoder enum, or be an integer value from
  * 0 to 7 inclusive.
- * 
+ *
  * Shorthand syntax:
  * Operand types can also be defined in a general shorthand form for
  * convenience. For example, `r/m16` will be generated and expanded
  * into both `r16` and `m16` operand types, with the encoder field
- * 
- * Operands can also be defined lacking the operand size trailing the 
- * type such as simply `r`, or `imm`, expanding into all respective 
- * sizes of the type provided. 
- * 
+ *
+ * Operands can also be defined lacking the operand size trailing the
+ * type such as simply `r`, or `imm`, expanding into all respective
+ * sizes of the type provided.
+ *
  * Shorthand formats for encoder options are as follows:
  * - /[0-7]: Maps to the integer value for the `reg` field.
  * - r/m: Corresponds to the `ENC_RM` encoder, with `/` removed.
- * 
+ *
  * All `/`'s will be removed from the final output, and all char-
- * acters in the encoder field will be converted to uppercase to 
+ * acters in the encoder field will be converted to uppercase to
  * match the format as expected by the enum.
- * 
+ *
  * Licensing details appear below:
  *
  * MIT License
@@ -129,6 +129,15 @@ instructions.forEach((instr) => {
   produceOperands(instr);
 });
 
+function literalValue(operand) {
+  if (operand.encoder != "literal") return "{ 0 }";
+
+  const operandType = operand.type.toUpperCase();
+  if (operandType.includes("IMM")) return `{ .imm = ${operand.value} }`;
+  if (operandType.includes("R"))
+    return `{ .reg = REG_${operand.value.toUpperCase()} }`;
+}
+
 function handleOperands(operands) {
   let res = "";
 
@@ -140,7 +149,7 @@ function handleOperands(operands) {
     if (match) encoder = `(enum enc_ident)${match[1]}`;
     encoder = encoder.replace("/", "");
 
-    res += `{ .type = OP_${type}, .encoder = ${encoder} }, `;
+    res += `{ .type = OP_${type}, .encoder = ${encoder}, .literal = ${literalValue(operands[i])}, }, `;
   }
 
   return `{${res}${"{ 0 }, ".repeat(4 - operands.length)}}`;

--- a/libjas/encoders/scripts/construct.js
+++ b/libjas/encoders/scripts/construct.js
@@ -18,16 +18,16 @@
  *
  * (where `x` is the operand index starting from 1)
  *
- * The construction of the CSV file can be done by exporting any type 
+ * The construction of the CSV file can be done by exporting any type
  * of spreadsheet file via any spreadsheet software that supports the
  * export of the file through CSV, as long as the headers remain con-
- * sistent with the above format. 
- * 
- * You can use this https://shorturl.at/DW73H Google Drive link as a 
- * template for the CSV file. You may download or make a copy of the 
+ * sistent with the above format.
+ *
+ * You can use this https://shorturl.at/DW73H Google Drive link as a
+ * template for the CSV file. You may download or make a copy of the
  * spreadsheet for editing on your own before conversion to the CSV
  * file format.
- * 
+ *
  * Licensing details appear below:
  *
  * MIT License
@@ -121,6 +121,6 @@ function constructYamlFile() {
         noRefs: true,
         styles: { "!!null": "empty", "!!int": "hexadecimal" },
       })
-      .replaceAll("'", "")
+      .replaceAll("'", ""),
   );
 }

--- a/libjas/include/encoder.h
+++ b/libjas/include/encoder.h
@@ -54,6 +54,7 @@ enum enc_ident {
   ENC_IGNORE,
   ENC_DEFAULT,
   ENC_OPCODE_APPENDED,
+  ENC_LITERAL,
 };
 
 typedef struct enc_serialized_instr {

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -39,18 +39,10 @@ typedef struct instr_encode_table instr_encode_table_t;
 #define INSTR_ENUM
 #include "instructions.inc"
 
+typedef struct op_descriptor op_descriptor_t;
 struct instr_encode_table {
-  uint8_t opcode[3]; /* Opcode of the instruction */
-
-  struct {
-    enum operands type;     /* Type of operand, for error checking purposes */
-    enum enc_ident encoder; /* Instruction encoder identity for that operand */
-
-    union {
-      uint64_t imm;       /* Literal immediate value to be matched */
-      enum registers reg; /* Literal register value */
-    } literal;            /* Literal data for the encoder, if applicable */
-  } operand_descriptors[4];
+  uint8_t opcode[3];                      /* Opcode of the instruction */
+  op_descriptor_t operand_descriptors[4]; /* List of operand descriptors */
 
   /// @note describes the validity of the instruction as in adherence to
   /// Intel-associated documentation.

--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -45,6 +45,11 @@ struct instr_encode_table {
   struct {
     enum operands type;     /* Type of operand, for error checking purposes */
     enum enc_ident encoder; /* Instruction encoder identity for that operand */
+
+    union {
+      uint64_t imm;       /* Literal immediate value to be matched */
+      enum registers reg; /* Literal register value */
+    } literal;            /* Literal data for the encoder, if applicable */
   } operand_descriptors[4];
 
   /// @note describes the validity of the instruction as in adherence to

--- a/libjas/include/operand.h
+++ b/libjas/include/operand.h
@@ -168,10 +168,10 @@ typedef union op_mem_src {
 /// portability and readability when dealing with instruction creation.
 typedef struct op_mem {
   enum { LABEL,
-         SIB } src_type; // Source type selector enumeration
+         SIB } src_type; /* Source type selector enumeration */
 
-  union op_mem_src src; // Source of memory operand, refer to `op_mem_src`
-  uint64_t disp;        // RIP addressing requires 32-bit displacement
+  union op_mem_src src; /* Source of memory operand, refer to `op_mem_src` */
+  uint64_t disp;        /* Displacement value applied on the memory reference */
 } op_mem_t;
 
 typedef struct operand {

--- a/libjas/include/operand.h
+++ b/libjas/include/operand.h
@@ -137,6 +137,16 @@ enum operands {
 
 #define op_rm(x) (op_r(x) || op_m(x))
 
+// --
+// clang-format off
+
+#define op_case_r case OP_R8: case OP_R16: case OP_R32: case OP_R64
+#define op_case_m case OP_M8: case OP_M16: case OP_M32: case OP_M64
+#define op_case_imm case OP_IMM8: case OP_IMM16: case OP_IMM32: case OP_IMM64
+#define op_case_rel case OP_REL8: case OP_REL16: case OP_REL32
+
+// clang-format on
+
 enum op_sib_scale {
   OP_SIB_SCALE_1 = 0,
   OP_SIB_SCALE_2 = 1,
@@ -258,19 +268,27 @@ uint8_t op_sizeof(enum operands input);
  */
 uint8_t op_disp_size(uint64_t displacement);
 
+typedef struct op_descriptor {
+  enum operands type;     /* Type of operand, for error checking purposes */
+  enum enc_ident encoder; /* Instruction encoder identity for that operand */
+
+  union {
+    uint64_t imm;       /* Literal immediate value to be matched */
+    enum registers reg; /* Literal register value */
+  } literal;            /* Literal data for the encoder, if applicable */
+} op_descriptor_t;
+
 /**
- * Function for asserting that the types of the input operand
- * array matches the expected operand types provided in the
- * expected operand array.
+ * Function for asserting the validity of an operand's type and
+ * value information against expected values as indicated to by
+ * the operand descriptor provided.
  *
- * @param in The input operand array to check against `ex`
- * @param ex List of expected operand types in enumerated form.
+ * @param in The Input operand array t be checked against.
+ * @param expected Operand descriptor array to be asserted.
  *
- * @param sz The size of the arrays provided.
- *
- * @return The result of the assertion; true if all types match
- * with the expected types, false otherwise.
+ * @return The result of the assertion, whether the input operands
+ * matches the expected operand descriptor's requirements.
  */
-bool op_assert_types(operand_t *in, enum operands *ex, size_t sz);
+bool op_assert_descriptor(operand_t in, op_descriptor_t expected);
 
 #endif

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -43,15 +43,14 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
   #include "instructions.inc"
   // clang-format on
 
-  for (uint8_t i = 1; CURR_TABLE[i].opcode_size; i++) {
-    const enum operands operand_list[4] = {
-        CURR_TABLE[i].operand_descriptors[0].type,
-        CURR_TABLE[i].operand_descriptors[1].type,
-        CURR_TABLE[i].operand_descriptors[2].type,
-        CURR_TABLE[i].operand_descriptors[3].type,
-    };
+  for (uint8_t i = 0; CURR_TABLE[i].opcode_size; i++) {
+    bool pass = false; // Represents if current table passes match
+    for (uint8_t j = 0; j < 4; j++) {
+      op_descriptor_t *ex = CURR_TABLE[i].operand_descriptors;
 
-    bool pass = op_assert_types(&instr.operands, operand_list, 4);
+      pass = op_assert_descriptor(instr.operands[j], ex[j]);
+      if (!pass) break; // No need to check further
+    }
     if (pass) return CURR_TABLE[i];
   }
 

--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -30,14 +30,6 @@
 #include <limits.h>
 #include <stdbool.h>
 
-bool op_assert_types(operand_t *in, enum operands *ex, size_t sz) {
-  for (size_t i = 0; i < sz; i++) {
-    if (ex[i] == OP_NULL) break;
-    if (in[i].type != ex[i]) return false;
-  }
-
-  return true;
-}
 // clang-format off
 #define mode_return(size, mode) { if (sz) *sz = size; return mode; }
 
@@ -64,6 +56,22 @@ enum op_modrm_modes op_modrm_mode(uint64_t displacement, uint8_t *sz) {
 }
 
 #undef mode_return
+
+bool op_assert_descriptor(operand_t in, op_descriptor_t expected) {
+  if (in.type != expected.type) return false;
+
+  if (expected.encoder == ENC_LITERAL) {
+    switch (expected.type) {
+    op_case_r:
+      if (in.mem.src_type != SIB) return false;
+      return in.mem.src.sib.reg == expected.literal.reg;
+      
+    op_case_imm: return in.imm == expected.literal.imm;
+    default: return false;
+    }
+  }
+}
+
 // clang-format on
 
 uint8_t op_sizeof(enum operands input) {


### PR DESCRIPTION
This pull will add support for literal operand matching in the Jas encoder. Some operands expected as part of the instructions in the Intel x86 system are matched with *exact* operand type and value combinations. For instance, simple arithmetic instructions such as `add` contains the case: `add eax, imm32` where operand 1 has to be matched with an appropriate type (of `r32` in this case) *and* a operand value (`eax` in said example).

Currently, Jas *does not* offer any means to enable this behaviour directly out of the box. This pull will aim to add a `literal` member representing the operand *value* to be matched where this behaviour is enabled. It is proposed that when the operand descriptor's encoder option is set to `ENC_LITERAL`, the encoder will match the operand with *both* the operand type in `type` **and** the data relevant in `literal` to the supplied `type` structure member.