### PR TITLE
Compiler implementation to literal operands

### DIFF
--- a/libjas/encoders/add.yml
+++ b/libjas/encoders/add.yml
@@ -1,6 +1,38 @@
 instructions:
   - add:
     variants:
+      - opcode: [0x04]
+        operands:
+          - { type: r8, encoder: literal, value: al }
+          - { type: imm8, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x05]
+        operands:
+          - { type: r16, encoder: literal, value: ax }
+          - { type: imm16, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x05]
+        operands:
+          - { type: r32, encoder: literal, value: eax }
+          - { type: imm32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
+      - opcode: [0x05]
+        operands:
+          - { type: r64, encoder: literal, value: rax }
+          - { type: imm32, encoder: default }
+        compatibility:
+          long: true
+          legacy: true
+
       - opcode: [0x80]
         operands:
           - { type: r/m8, encoder: /4 }

--- a/libjas/encoders/scripts/compile.js
+++ b/libjas/encoders/scripts/compile.js
@@ -27,28 +27,28 @@
  * @note `js-yaml` package must be installed and accessible to allow
  * yaml parsing functionality to be used.
  *
- * Encoder options are to be filled in each operand definition's 
+ * Encoder options are to be filled in each operand definition's
  * `encoder` field. The value of the `encoder` field is to either
- * map to a predefined encoder enum, or be an integer value from 
+ * map to a predefined encoder enum, or be an integer value from
  * 0 to 7 inclusive.
- * 
+ *
  * Shorthand syntax:
  * Operand types can also be defined in a general shorthand form for
  * convenience. For example, `r/m16` will be generated and expanded
  * into both `r16` and `m16` operand types, with the encoder field
- * 
- * Operands can also be defined lacking the operand size trailing the 
- * type such as simply `r`, or `imm`, expanding into all respective 
- * sizes of the type provided. 
- * 
+ *
+ * Operands can also be defined lacking the operand size trailing the
+ * type such as simply `r`, or `imm`, expanding into all respective
+ * sizes of the type provided.
+ *
  * Shorthand formats for encoder options are as follows:
  * - /[0-7]: Maps to the integer value for the `reg` field.
  * - r/m: Corresponds to the `ENC_RM` encoder, with `/` removed.
- * 
+ *
  * All `/`'s will be removed from the final output, and all char-
- * acters in the encoder field will be converted to uppercase to 
+ * acters in the encoder field will be converted to uppercase to
  * match the format as expected by the enum.
- * 
+ *
  * Licensing details appear below:
  *
  * MIT License
@@ -129,6 +129,15 @@ instructions.forEach((instr) => {
   produceOperands(instr);
 });
 
+function literalValue(operand) {
+  if (operand.encoder != "literal") return "{ 0 }";
+
+  const operandType = operand.type.toUpperCase();
+  if (operandType.includes("IMM")) return `{ .imm = ${operand.value} }`;
+  if (operandType.includes("R"))
+    return `{ .reg = REG_${operand.value.toUpperCase()} }`;
+}
+
 function handleOperands(operands) {
   let res = "";
 
@@ -140,7 +149,7 @@ function handleOperands(operands) {
     if (match) encoder = `(enum enc_ident)${match[1]}`;
     encoder = encoder.replace("/", "");
 
-    res += `{ .type = OP_${type}, .encoder = ${encoder} }, `;
+    res += `{ .type = OP_${type}, .encoder = ${encoder}, .literal = ${literalValue(operands[i])}, }, `;
   }
 
   return `{${res}${"{ 0 }, ".repeat(4 - operands.length)}}`;

--- a/libjas/encoders/scripts/construct.js
+++ b/libjas/encoders/scripts/construct.js
@@ -18,16 +18,16 @@
  *
  * (where `x` is the operand index starting from 1)
  *
- * The construction of the CSV file can be done by exporting any type 
+ * The construction of the CSV file can be done by exporting any type
  * of spreadsheet file via any spreadsheet software that supports the
  * export of the file through CSV, as long as the headers remain con-
- * sistent with the above format. 
- * 
- * You can use this https://shorturl.at/DW73H Google Drive link as a 
- * template for the CSV file. You may download or make a copy of the 
+ * sistent with the above format.
+ *
+ * You can use this https://shorturl.at/DW73H Google Drive link as a
+ * template for the CSV file. You may download or make a copy of the
  * spreadsheet for editing on your own before conversion to the CSV
  * file format.
- * 
+ *
  * Licensing details appear below:
  *
  * MIT License
@@ -121,6 +121,6 @@ function constructYamlFile() {
         noRefs: true,
         styles: { "!!null": "empty", "!!int": "hexadecimal" },
       })
-      .replaceAll("'", "")
+      .replaceAll("'", ""),
   );
 }


### PR DESCRIPTION
This pull adds the required logic for the implementation of the literal operand fields as proposed in #152. 

The pull adds functionality for the handling of the `value` field present in each operand descriptor. Additionally, it also pads non-applicable literal operand fields where not required, allowing previous encoder reference tables and tables not using said function to be integrated.

> [!NOTE]
> This pull **only** adds said functionality to the *compiler* script. This means, the feature has yet to be integrated for the shorthand syntax in the `.csv` format. A subsequent pull can be expected to allow the streamlined addition of encoder reference tables containing a need for literal operands.