### PR TITLE
Implementation of new operand checking methodology

### DIFF
--- a/libjas/include/instruction.h
+++ b/libjas/include/instruction.h
@@ -39,18 +39,10 @@ typedef struct instr_encode_table instr_encode_table_t;
 #define INSTR_ENUM
 #include "instructions.inc"
 
+typedef struct op_descriptor op_descriptor_t;
 struct instr_encode_table {
-  uint8_t opcode[3]; /* Opcode of the instruction */
-
-  struct {
-    enum operands type;     /* Type of operand, for error checking purposes */
-    enum enc_ident encoder; /* Instruction encoder identity for that operand */
-
-    union {
-      uint64_t imm;       /* Literal immediate value to be matched */
-      enum registers reg; /* Literal register value */
-    } literal;            /* Literal data for the encoder, if applicable */
-  } operand_descriptors[4];
+  uint8_t opcode[3];                      /* Opcode of the instruction */
+  op_descriptor_t operand_descriptors[4]; /* List of operand descriptors */
 
   /// @note describes the validity of the instruction as in adherence to
   /// Intel-associated documentation.

--- a/libjas/include/operand.h
+++ b/libjas/include/operand.h
@@ -137,6 +137,16 @@ enum operands {
 
 #define op_rm(x) (op_r(x) || op_m(x))
 
+// --
+// clang-format off
+
+#define op_case_r case OP_R8: case OP_R16: case OP_R32: case OP_R64
+#define op_case_m case OP_M8: case OP_M16: case OP_M32: case OP_M64
+#define op_case_imm case OP_IMM8: case OP_IMM16: case OP_IMM32: case OP_IMM64
+#define op_case_rel case OP_REL8: case OP_REL16: case OP_REL32
+
+// clang-format on
+
 enum op_sib_scale {
   OP_SIB_SCALE_1 = 0,
   OP_SIB_SCALE_2 = 1,
@@ -258,19 +268,27 @@ uint8_t op_sizeof(enum operands input);
  */
 uint8_t op_disp_size(uint64_t displacement);
 
+typedef struct op_descriptor {
+  enum operands type;     /* Type of operand, for error checking purposes */
+  enum enc_ident encoder; /* Instruction encoder identity for that operand */
+
+  union {
+    uint64_t imm;       /* Literal immediate value to be matched */
+    enum registers reg; /* Literal register value */
+  } literal;            /* Literal data for the encoder, if applicable */
+} op_descriptor_t;
+
 /**
- * Function for asserting that the types of the input operand
- * array matches the expected operand types provided in the
- * expected operand array.
+ * Function for asserting the validity of an operand's type and
+ * value information against expected values as indicated to by
+ * the operand descriptor provided.
  *
- * @param in The input operand array to check against `ex`
- * @param ex List of expected operand types in enumerated form.
+ * @param in The Input operand array t be checked against.
+ * @param expected Operand descriptor array to be asserted.
  *
- * @param sz The size of the arrays provided.
- *
- * @return The result of the assertion; true if all types match
- * with the expected types, false otherwise.
+ * @return The result of the assertion, whether the input operands
+ * matches the expected operand descriptor's requirements.
  */
-bool op_assert_types(operand_t *in, enum operands *ex, size_t sz);
+bool op_assert_descriptor(operand_t in, op_descriptor_t expected);
 
 #endif

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -43,13 +43,13 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
   #include "instructions.inc"
   // clang-format on
 
-  for (uint8_t i = 1; CURR_TABLE[i].opcode_size; i++) {
+  for (uint8_t i = 0; CURR_TABLE[i].opcode_size; i++) {
     bool pass = false; // Represents if current table passes match
     for (uint8_t j = 0; j < 4; j++) {
-      op_descriptor_t *descriptors = CURR_TABLE[i].operand_descriptors;
+      op_descriptor_t *ex = CURR_TABLE[i].operand_descriptors;
 
-      pass = op_assert_descriptor(instr.operands[j], descriptors[j]);
-      if (!pass) break; // No need to check further if one operand fails
+      pass = op_assert_descriptor(instr.operands[j], ex[j]);
+      if (!pass) break; // No need to check further
     }
     if (pass) return CURR_TABLE[i];
   }

--- a/libjas/instruction.c
+++ b/libjas/instruction.c
@@ -44,14 +44,13 @@ instr_encode_table_t instr_get_tab(instruction_t instr) {
   // clang-format on
 
   for (uint8_t i = 1; CURR_TABLE[i].opcode_size; i++) {
-    const enum operands operand_list[4] = {
-        CURR_TABLE[i].operand_descriptors[0].type,
-        CURR_TABLE[i].operand_descriptors[1].type,
-        CURR_TABLE[i].operand_descriptors[2].type,
-        CURR_TABLE[i].operand_descriptors[3].type,
-    };
+    bool pass = false; // Represents if current table passes match
+    for (uint8_t j = 0; j < 4; j++) {
+      op_descriptor_t *descriptors = CURR_TABLE[i].operand_descriptors;
 
-    bool pass = op_assert_types(&instr.operands, operand_list, 4);
+      pass = op_assert_descriptor(instr.operands[j], descriptors[j]);
+      if (!pass) break; // No need to check further if one operand fails
+    }
     if (pass) return CURR_TABLE[i];
   }
 

--- a/libjas/operand.c
+++ b/libjas/operand.c
@@ -30,14 +30,6 @@
 #include <limits.h>
 #include <stdbool.h>
 
-bool op_assert_types(operand_t *in, enum operands *ex, size_t sz) {
-  for (size_t i = 0; i < sz; i++) {
-    if (ex[i] == OP_NULL) break;
-    if (in[i].type != ex[i]) return false;
-  }
-
-  return true;
-}
 // clang-format off
 #define mode_return(size, mode) { if (sz) *sz = size; return mode; }
 
@@ -64,6 +56,22 @@ enum op_modrm_modes op_modrm_mode(uint64_t displacement, uint8_t *sz) {
 }
 
 #undef mode_return
+
+bool op_assert_descriptor(operand_t in, op_descriptor_t expected) {
+  if (in.type != expected.type) return false;
+
+  if (expected.encoder == ENC_LITERAL) {
+    switch (expected.type) {
+    op_case_r:
+      if (in.mem.src_type != SIB) return false;
+      return in.mem.src.sib.reg == expected.literal.reg;
+      
+    op_case_imm: return in.imm == expected.literal.imm;
+    default: return false;
+    }
+  }
+}
+
 // clang-format on
 
 uint8_t op_sizeof(enum operands input) {


### PR DESCRIPTION
This is a sub-pull of the divergent branch `literal-operands` as per #152, adding the newly improved operand checking methodology associated with the implementation of literal operands. 

As the primary objective for the implementation of support for literal operands is to enable the encoding of specific instructions with instruction encoding signatures with *both* an operand type and value; the operand checking mechanism must be expanded to perform error checking operations with regards to both operand types and values when specified as literal. 

### What Changed 

This pull saw the addition of the `op_assert_descriptor` function that will succeed the `op_assert_types` function previously implemented for determining a suitable instruction encoder table. The `op_assert_descriptor` specifically allows operands to be checked against an operand descriptor, aligned with the instruction encoder table's needs. This includes, checking of the operand values when deemed necessary by the usage of the `ENC_LITERAL` encoder modifier. 

**Miscellaneous Changes**

Additionally, the operand descriptors have now been isolated from the initial `instr_encode_table` structure type and has since been moved to the `operand.h` source file in the form of the `op_descriptor_t` type, better aligning to the operand descriptor's intended usage.

Furthermore, the addition of helper macros associated with the checking of the operand types via a `switch` has also been added as part of the operand module. Akin to the previous operand conditional macros such as `op_r` or `op_rel`, that can be plugged into a `if` statement to determine an `operands` enum's type; a set of `op_case_` macros have been added that filters operands as part of a particular group, checked through a `switch` statement, rather than an `if`.

**Additional steps**

All changes specified in this pull will be documented in the corresponding `jas-doc` files. The invalid `op_assert_types` function document will also be removed and updated with the successor `op_assert_descriptor` function. 