### PR TITLE
Rectified missing instruction string bug

### DIFF
--- a/libjas/encoders/scripts/compile.js
+++ b/libjas/encoders/scripts/compile.js
@@ -231,7 +231,7 @@ function generateEnumNames(instructions) {
 
 function generateInstructionNames(names) {
   let instrNames = "char *instr_tab_names[] = {\n";
-  for (let n = 1; n < names.length; n++) {
+  for (let n = 0; n < names.length; n++) {
     instrNames += `  "${names[n]}",`;
   }
 


### PR DESCRIPTION
This simple commit changes the index of the compiler's loop as previously mistakenly set as `1`. As the previous loop began to iterate from the 2nd element, the first element's string name *would essentially* never be written to the string lookup array in the final output. 

Additionally, there would've also been a mismatch of instruction enum and string indexes as the string were offset by 1 element. This pull changes the value to `0`, allowing the loop to begin from the start of the array where is most suitable.