### PR TITLE
Implementation of the `capacity` field in` buffer_t`

### DIFF
--- a/libjas/buffer.c
+++ b/libjas/buffer.c
@@ -31,11 +31,14 @@
 #include <stdlib.h>
 
 void buf_write(buffer_t *buf, const uint8_t *data, const size_t data_len) {
-  if (data_len < 1)
-    return;
+  if (data_len < 1) return;
 
-  buf->data =
-      (uint8_t *)(buf->data == NULL ? malloc(data_len) : realloc(buf->data, buf->len + data_len));
+  // clang-format off
+  const size_t total = buf->len + data_len;
+  if (!buf->capacity || buf->capacity < total) {
+    buf->data = buf->data == NULL ? malloc(data_len) : 
+        realloc(buf->data, total);
+  } // clang-format on
 
   for (size_t i = 0; i < data_len; i++)
     buf->data[buf->len + i] = data[i];
@@ -55,6 +58,8 @@ void buf_remove(buffer_t *buf, const size_t elem) {
     buf->data[i] = buf->data[i + 1];
 
   buf->len--;
+  if (buf->capacity) return;
+
   buf->data = realloc(buf->data, buf->len);
 }
 

--- a/libjas/include/buffer.h
+++ b/libjas/include/buffer.h
@@ -33,6 +33,15 @@
 typedef struct {
   uint8_t *data; /* Buffer data */
   size_t len;    /* Length of buffer */
+
+  /// @brief Allows the buffer to reduce the number of
+  /// heap reallocations by keeping track of the pre-
+  /// dicted capacity of the buffer.
+
+  size_t capacity; /* Capacity of buffer */
+
+  /// @note If capacity is set, the buffer will give all
+  /// control to the caller to manage buffer's memory size.
 } buffer_t;
 
 void buf_write(buffer_t *buf, const uint8_t *data, const size_t data_len);
@@ -42,7 +51,8 @@ void buf_remove(buffer_t *buf, const size_t elem);
 #define BUF_NULL    \
   (buffer_t){       \
       .data = NULL, \
-      .len = 0}
+      .len = 0,     \
+      .capacity = 0}
 
 bool buf_element_exists(buffer_t *buf, const uint8_t elem);
 void buf_concat(buffer_t *buf, size_t count, ...);


### PR DESCRIPTION
This pull implements the `capacity` field in the `buffer_t` object as well as corresponding logic for the handling of said field. It has been concluded that arbitrary calls to `realloc` is not required, especially since the expected size of the total buffer can be reliability predicted via the published `encoded_size` element of `enc_serialized_instr_t`. 

The usage of the `capacity` field allows the caller to bypass any `buffer_t`-imposed heap allocation and memory allocation rules, handing responsibility for the allocation of data to the caller. For instance, if the caller is able to provide a *predetermined* buffer size, the caller may allocate heap memory manually, setting the allocated size in `capacity`; therefore, eliminating the buffer module functions' need to reallocate *after each write instance*. 