### PR TITLE
Added additional case to process literal operands

### DIFF
--- a/libjas/encoders/scripts/construct.js
+++ b/libjas/encoders/scripts/construct.js
@@ -103,6 +103,13 @@ function constructYamlFile() {
         type: current[`type-${operandCount}`],
         encoder: current[`encoder-${operandCount}`],
       };
+      const match = current[`encoder-${operandCount}`].match(/^\{.*\}$/);
+
+      if (match) {
+        operand.encoder = "literal";
+        operand.value = match[0].slice(1, -1);
+      }
+
       variant.operands.push(operand);
       operandCount++;
     }


### PR DESCRIPTION
This pull adds additional functionality to the csv compiler script to support the input with fields that specify operands with set operand data. As implemented in #152, which saw the support of literal operands, the current pull has expanded the ability to express operands as such.

### Usage

To express a literal operand, that is, where the assembler will process and cross check *both* the operand type *and* value. The `encoder-x` field on the csv file is to be set to `{...}` where data between braces represent a value that is to be expected.  A `ENC_LITERAL` operand encoder modifier is to be inferred through the use of curly braces and is automatically set by the YAML generator. 

Additionally, the type in which the literal should be processed as is referenced by the operand's corresponding type. This information is to be specified in the `type-x` field